### PR TITLE
[#6] CustomDataJpaTest 어노테이션

### DIFF
--- a/src/test/java/com/prgrms/tenwonmoa/common/annotation/CustomDataJpaTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/annotation/CustomDataJpaTest.java
@@ -7,8 +7,11 @@ import java.lang.annotation.Target;
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
+
+import com.prgrms.tenwonmoa.config.TestConfig;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -16,5 +19,6 @@ import org.springframework.test.context.ActiveProfiles;
 @EnableJpaAuditing
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestConfig.class)
 public @interface CustomDataJpaTest {
 }

--- a/src/test/java/com/prgrms/tenwonmoa/common/annotation/CustomDataJpaTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/annotation/CustomDataJpaTest.java
@@ -1,0 +1,20 @@
+package com.prgrms.tenwonmoa.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@DataJpaTest
+@EnableJpaAuditing
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public @interface CustomDataJpaTest {
+}

--- a/src/test/java/com/prgrms/tenwonmoa/config/TestConfig.java
+++ b/src/test/java/com/prgrms/tenwonmoa/config/TestConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @TestConfiguration
-class TestConfig {
+public class TestConfig {
 
 	@PersistenceContext
 	private EntityManager entityManager;

--- a/src/test/java/com/prgrms/tenwonmoa/config/TestConfig.java
+++ b/src/test/java/com/prgrms/tenwonmoa/config/TestConfig.java
@@ -1,0 +1,21 @@
+package com.prgrms.tenwonmoa.config;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@TestConfiguration
+class TestConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}


### PR DESCRIPTION
## 개요

CustomDataJpa Annotaion 추가

## 추가기능

- 임베디드 데이터베이스 아닌 실제 디비로 연결 
  - @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
- QueryDsl을 위한 TestConfig 만들고 CustomDataJpaTest에 @Import(TestConfig.class)


## 사용방법(Optional)

RepositoryTest에 Anotaion 붙이면 된다.

@CustomDataJpaTest
class SampleRepositoryTest{
}


