### PR TITLE
[#29] 수입등록 서비스 구현 - Service

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateIncomeRequest.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateIncomeRequest.java
@@ -1,0 +1,49 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import java.time.LocalDate;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.user.User;
+
+public class CreateIncomeRequest {
+	@NotNull
+	private final LocalDate registerDate;
+
+	@Min(1L)
+	@Max(1000000000000L)
+	private final Long amount;
+
+	@Size(max = 50)
+	private final String content;
+
+	@NotNull
+	private final Long userCategoryId;
+
+	public CreateIncomeRequest(LocalDate registerDate, Long amount, String content, Long userCategoryId) {
+		this.registerDate = registerDate;
+		this.amount = amount;
+		this.content = content;
+		this.userCategoryId = userCategoryId;
+	}
+
+	public Income toEntity(User user, UserCategory userCategory, String categoryName) {
+		return new Income(
+			this.registerDate,
+			this.amount,
+			this.content,
+			categoryName,
+			user,
+			userCategory
+		);
+	}
+
+	public Long getUserCategoryId() {
+		return userCategoryId;
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookService.java
@@ -1,0 +1,31 @@
+package com.prgrms.tenwonmoa.domain.accountbook.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AccountBookService {
+	private final UserService userService;
+	private final UserCategoryService userCategoryService;
+	private final IncomeService incomeService;
+
+	@Transactional
+	public Long createIncome(Long userId, CreateIncomeRequest createIncomeRequest) {
+		User user = userService.findById(userId);
+		UserCategory userCategory = userCategoryService.findById(createIncomeRequest.getUserCategoryId());
+		Income income = createIncomeRequest.toEntity(user, userCategory, userCategory.getCategory().getName());
+
+		return incomeService.save(income);
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
@@ -1,0 +1,22 @@
+package com.prgrms.tenwonmoa.domain.accountbook.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class IncomeService {
+
+	private final IncomeRepository incomeRepository;
+
+	@Transactional
+	public Long save(Income income) {
+		return incomeRepository.save(income).getId();
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepository.java
@@ -17,4 +17,8 @@ public interface UserCategoryRepository extends JpaRepository<UserCategory, Long
 		+ " and uc.category.id =:categoryId")
 	Optional<UserCategory> findByUserAndCategory(Long userId, Long categoryId);
 
+	@Override
+	@Query("select uc from UserCategory uc join fetch uc.category where uc.id = :userCategoryId")
+	Optional<UserCategory> findById(Long userCategoryId);
+
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryService.java
@@ -1,0 +1,25 @@
+package com.prgrms.tenwonmoa.domain.category.service;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
+import com.prgrms.tenwonmoa.exception.message.Message;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserCategoryService {
+
+	private final UserCategoryRepository userCategoryRepository;
+
+	public UserCategory findById(Long userCategoryId) {
+		return userCategoryRepository.findById(userCategoryId)
+			.orElseThrow(() -> new NoSuchElementException(Message.USER_CATEGORY_NOT_FOUND.getMessage()));
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
@@ -1,0 +1,25 @@
+package com.prgrms.tenwonmoa.domain.user.service;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
+import com.prgrms.tenwonmoa.exception.message.Message;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	public User findById(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new NoSuchElementException(Message.USER_NOT_FOUND.getMessage()));
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/fixture/Fixture.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/fixture/Fixture.java
@@ -1,5 +1,11 @@
 package com.prgrms.tenwonmoa.common.fixture;
 
+import java.time.LocalDate;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.CategoryType;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
 
 public final class Fixture {
@@ -10,4 +16,21 @@ public final class Fixture {
 		return new User("test@gmail.com", "123456789", "testuser");
 	}
 
+	public static Category createCategory() {
+		return new Category("categoryName", CategoryType.INCOME);
+	}
+
+	public static UserCategory createUserCategory() {
+		return new UserCategory(createUser(), createCategory());
+	}
+
+	public static Income createIncome() {
+		UserCategory userCategory = createUserCategory();
+		return new Income(LocalDate.now(),
+			1000L,
+			"content",
+			userCategory.getCategory().getName(),
+			userCategory.getUser(),
+			userCategory);
+	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookServiceTest.java
@@ -1,0 +1,78 @@
+package com.prgrms.tenwonmoa.domain.accountbook.service;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.service.UserService;
+import com.prgrms.tenwonmoa.exception.message.Message;
+
+@DisplayName("가계부 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class AccountBookServiceTest {
+
+	@Mock
+	private UserService userService;
+	@Mock
+	private UserCategoryService userCategoryService;
+	@Mock
+	private IncomeService incomeService;
+	@InjectMocks
+	private AccountBookService accountBookService;
+
+	private final Income income = createIncome();
+	private final UserCategory userCategory = income.getUsercategory();
+	private final User user = income.getUser();
+
+	private final CreateIncomeRequest request = new CreateIncomeRequest(LocalDate.now(),
+		1000L,
+		"content",
+		1L);
+
+	@Test
+	void 수입_생성_성공() {
+		given(userService.findById(any())).willReturn(user);
+		given(userCategoryService.findById(any())).willReturn(userCategory);
+		given(incomeService.save(income)).willReturn(1L);
+
+		Long savedId = accountBookService.createIncome(user.getId(), request);
+		assertAll(
+			() -> assertThat(savedId).isEqualTo(1L),
+			() -> verify(incomeService).save(income)
+		);
+	}
+
+	@Test
+	void 수입_생성실패_유저정보_없는경우() {
+		given(userService.findById(any())).willThrow(new NoSuchElementException(Message.USER_NOT_FOUND.getMessage()));
+		assertThatThrownBy(() -> accountBookService.createIncome(user.getId(), request))
+			.isInstanceOf(NoSuchElementException.class)
+			.hasMessage(Message.USER_NOT_FOUND.getMessage());
+	}
+
+	@Test
+	void 수입_생성실패_유저카테고리_없는경우() {
+		given(userService.findById(any())).willReturn(user);
+		given(userCategoryService.findById(any())).willThrow(
+			new NoSuchElementException(Message.USER_CATEGORY_NOT_FOUND.getMessage()));
+		assertThatThrownBy(() -> accountBookService.createIncome(user.getId(), request))
+			.isInstanceOf(NoSuchElementException.class)
+			.hasMessage(Message.USER_CATEGORY_NOT_FOUND.getMessage());
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
@@ -1,0 +1,39 @@
+package com.prgrms.tenwonmoa.domain.accountbook.service;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+
+@DisplayName("수입 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class IncomeServiceTest {
+	@Mock
+	private IncomeRepository incomeRepository;
+
+	@InjectMocks
+	private IncomeService incomeService;
+
+	private final Income income = createIncome();
+
+	@Test
+	void 수입저장_성공() {
+		given(incomeRepository.save(income)).willReturn(income);
+
+		Long savedId = incomeService.save(income);
+		assertAll(
+			() -> assertThat(savedId).isEqualTo(income.getId()),
+			() -> verify(incomeRepository).save(income)
+		);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepositoryTest.java
@@ -54,4 +54,16 @@ class UserCategoryRepositoryTest {
 			.extracting(UserCategory::getUser, UserCategory::getCategory)
 			.isEqualTo(List.of(user, category));
 	}
+
+	@Test
+	void 아이디로_유저카테고리_조회() {
+		// given
+		UserCategory savedUserCategory = userCategoryRepository.save(new UserCategory(user, category));
+		// when
+		Optional<UserCategory> userCategoryOptional = userCategoryRepository.findById(savedUserCategory.getId());
+		// then
+		assertThat(userCategoryOptional).isPresent();
+		UserCategory userCategory = userCategoryOptional.get();
+		assertThat(savedUserCategory).isEqualTo(userCategory);
+	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
@@ -19,7 +19,7 @@ import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
 import com.prgrms.tenwonmoa.exception.message.Message;
 
-@DisplayName("유저 카테고리 테스트")
+@DisplayName("유저 카테고리 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
 class UserCategoryServiceTest {
 	@Mock

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
@@ -1,0 +1,53 @@
+package com.prgrms.tenwonmoa.domain.category.service;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
+import com.prgrms.tenwonmoa.exception.message.Message;
+
+@DisplayName("유저 카테고리 테스트")
+@ExtendWith(MockitoExtension.class)
+class UserCategoryServiceTest {
+	@Mock
+	private UserCategoryRepository userCategoryRepository;
+
+	@InjectMocks
+	private UserCategoryService userCategoryService;
+
+	private final UserCategory userCategory = createUserCategory();
+
+	@Test
+	void 아이디로_유저카테고리조회_성공() {
+		given(userCategoryRepository.findById(userCategory.getId())).willReturn(Optional.of(userCategory));
+
+		UserCategory findUserCategory = userCategoryService.findById(userCategory.getId());
+		assertAll(
+			() -> assertThat(findUserCategory.getId()).isEqualTo(userCategory.getId()),
+			() -> verify(userCategoryRepository).findById(userCategory.getId())
+		);
+	}
+
+	@Test
+	void 아이디로_유저카테고리조회_실패() {
+		given(userCategoryRepository.findById(any())).willThrow(
+			new NoSuchElementException(Message.USER_CATEGORY_NOT_FOUND.getMessage()));
+
+		assertThatThrownBy(() -> userCategoryService.findById(any()))
+			.isInstanceOf(NoSuchElementException.class)
+			.hasMessage(Message.USER_CATEGORY_NOT_FOUND.getMessage());
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserServiceTest.java
@@ -1,0 +1,53 @@
+package com.prgrms.tenwonmoa.domain.user.service;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
+import com.prgrms.tenwonmoa.exception.message.Message;
+
+@DisplayName("유저 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private UserService userService;
+
+	private final User user = createUser();
+
+	@Test
+	void 아이디로_유저조회_성공() {
+		given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+		User findUser = userService.findById(user.getId());
+		assertAll(
+			() -> assertThat(findUser.getId()).isEqualTo(user.getId()),
+			() -> verify(userRepository).findById(user.getId())
+		);
+	}
+
+	@Test
+	void 아이디로_유저조회_실패() {
+		given(userRepository.findById(any())).willThrow(
+			new NoSuchElementException(Message.USER_NOT_FOUND.getMessage()));
+
+		assertThatThrownBy(() -> userService.findById(any()))
+			.isInstanceOf(NoSuchElementException.class)
+			.hasMessage(Message.USER_NOT_FOUND.getMessage());
+	}
+}


### PR DESCRIPTION
## 개요
- 사용자는 수입을 등록할 수 있다.
- 생각보다 변경된 코드가 많아 컨트롤러는 별도 PR요쳥하겠습니다.

## 추가기능
- 수입 등록 서비스
- 수입 등록시 필요한 다른도메인의 서비스도 같이 추가되었습니다.

## 사용방법(Optional)
- 수입 등록은 `AccountBookService`에서 처리합니다.
- Service에 대한 단위테스트는 기본적으로 모두 작성했습니다.

## 기타
<img width="244" alt="image" src="https://user-images.githubusercontent.com/26343023/181021790-11db780e-e394-45aa-8533-7f9591e3cc6c.png">
