### PR TITLE
[#23] 사용자는 지출을 삭제할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
@@ -42,11 +43,15 @@ public class Expenditure extends BaseEntity {
 	private String categoryName;
 
 	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "user_id")
+	@JoinColumn(
+		foreignKey = @ForeignKey(name = "fk_expenditure_user"),
+		name = "user_id")
 	private User user;
 
 	@OneToOne(fetch = LAZY)
-	@JoinColumn(name = "user_category_id")
+	@JoinColumn(
+		foreignKey = @ForeignKey(name = "fk_expenditure_user_category"),
+		name = "user_category_id")
 	private UserCategory userCategory;
 
 	public Expenditure(LocalDate registerDate, Long amount, String content,

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -28,7 +29,7 @@ public class ExpenditureController {
 
 	@PostMapping
 	public ResponseEntity<CreateExpenditureResponse> createExpenditure(
-		@RequestBody CreateExpenditureRequest createExpenditureRequest) throws URISyntaxException {
+		@Validated @RequestBody CreateExpenditureRequest createExpenditureRequest) throws URISyntaxException {
 		Long userId = 1L; // 추후 Auth로 받을 예정
 		CreateExpenditureResponse response = expenditureService.createExpenditure(userId, createExpenditureRequest);
 
@@ -39,14 +40,10 @@ public class ExpenditureController {
 	@PutMapping("/{expenditureId}")
 	public ResponseEntity<Void> updateExpenditure(
 		@PathVariable Long expenditureId,
-		@RequestBody UpdateExpenditureRequest updateExpenditureRequest) throws URISyntaxException {
+		@Validated @RequestBody UpdateExpenditureRequest updateExpenditureRequest) {
 		Long userId = 1L; // 추후 Auth로 받을 예정
 		expenditureService.updateExpenditure(userId, expenditureId, updateExpenditureRequest);
 
-		/**
-		 * TODO : 이부분 uri 어디로 지정해줘야할 지 프로트랑 의논 필요
-		 * */
-		URI uri = new URI(LOCATION_PREFIX + expenditureId);
-		return ResponseEntity.created(uri).build();
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
@@ -3,8 +3,9 @@ package com.prgrms.tenwonmoa.domain.accountbook.controller;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import javax.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,7 +31,7 @@ public class ExpenditureController {
 
 	@PostMapping
 	public ResponseEntity<CreateExpenditureResponse> createExpenditure(
-		@Validated @RequestBody CreateExpenditureRequest createExpenditureRequest) throws URISyntaxException {
+		@Valid @RequestBody CreateExpenditureRequest createExpenditureRequest) throws URISyntaxException {
 		Long userId = 1L; // 추후 Auth로 받을 예정
 		CreateExpenditureResponse response = expenditureService.createExpenditure(userId, createExpenditureRequest);
 
@@ -41,7 +42,7 @@ public class ExpenditureController {
 	@PutMapping("/{expenditureId}")
 	public ResponseEntity<Void> updateExpenditure(
 		@PathVariable Long expenditureId,
-		@Validated @RequestBody UpdateExpenditureRequest updateExpenditureRequest
+		@Valid @RequestBody UpdateExpenditureRequest updateExpenditureRequest
 	) {
 		Long userId = 1L; // 추후 Auth로 받을 예정
 		expenditureService.updateExpenditure(userId, expenditureId, updateExpenditureRequest);

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -40,10 +41,19 @@ public class ExpenditureController {
 	@PutMapping("/{expenditureId}")
 	public ResponseEntity<Void> updateExpenditure(
 		@PathVariable Long expenditureId,
-		@Validated @RequestBody UpdateExpenditureRequest updateExpenditureRequest) {
+		@Validated @RequestBody UpdateExpenditureRequest updateExpenditureRequest
+	) {
 		Long userId = 1L; // 추후 Auth로 받을 예정
 		expenditureService.updateExpenditure(userId, expenditureId, updateExpenditureRequest);
 
 		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping("/{expenditureId}")
+	public ResponseEntity<Void> deleteExpenditure(@PathVariable Long expenditureId) {
+		Long userId = 1L; // 추후 Auth로 받을 예정
+		expenditureService.deleteExpenditure(expenditureId);
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateExpenditureRequest.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateExpenditureRequest.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
@@ -19,7 +20,7 @@ public class CreateExpenditureRequest {
 	@Max(1000000000000L)
 	private final Long amount;
 
-	@Max(50)
+	@Size(max = 50)
 	private final String content;
 
 	@NotNull

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateExpenditureRequest.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateExpenditureRequest.java
@@ -19,6 +19,7 @@ public class CreateExpenditureRequest {
 	@Max(1000000000000L)
 	private final Long amount;
 
+	@Max(50)
 	private final String content;
 
 	@NotNull

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureService.java
@@ -54,6 +54,12 @@ public class ExpenditureService {
 		expenditure.update(userCategory, updateExpenditureRequest);
 	}
 
+	public void deleteExpenditure(Long expenditureId) {
+		Expenditure expenditure = getExpenditure(expenditureId);
+
+		expenditureRepository.delete(expenditure);
+	}
+
 	private void validateUser(User currentUser, User expenditureUser) {
 		checkArgument(currentUser == expenditureUser, Message.EXPENDITURE_NO_AUTHENTICATION.getMessage());
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
@@ -57,6 +57,9 @@ class ExpenditureServiceTest {
 	private final Expenditure expenditure = new Expenditure(LocalDate.now(), 10000L, "피자", category.getName(), user,
 		userCategory);
 
+	@Mock
+	private Expenditure mockExpenditure;
+
 	@Nested
 	@DisplayName("지출 생성 중")
 	class CreateExpenditureTest {
@@ -129,9 +132,6 @@ class ExpenditureServiceTest {
 
 		private final UpdateExpenditureRequest request = new UpdateExpenditureRequest(LocalDate.now(), 2000L,
 			"수정", userCategoryId);
-
-		@Mock
-		private Expenditure mockExpenditure;
 
 		@Test
 		public void 해당_유저가_없을_경우() {
@@ -208,5 +208,30 @@ class ExpenditureServiceTest {
 			verify(mockExpenditure).update(userCategory, request);
 		}
 
+	}
+
+	@Nested
+	@DisplayName("지출 삭제 중")
+	class DeleteExpenditureTEst {
+
+		@Test
+		public void 삭제하려는_지출이_없을때() {
+			given(expenditureRepository.findById(any()))
+				.willThrow(new NoSuchElementException(Message.EXPENDITURE_NOT_FOUND.getMessage()));
+
+			assertThatThrownBy(() -> expenditureService.deleteExpenditure(any()))
+				.isInstanceOf(NoSuchElementException.class)
+				.hasMessage(Message.EXPENDITURE_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		public void 지출을_성공적으로_삭제_할_때() {
+			given(expenditureRepository.findById(any()))
+				.willReturn(of(expenditure));
+
+			expenditureService.deleteExpenditure(any());
+
+			verify(expenditureRepository).delete(any());
+		}
 	}
 }


### PR DESCRIPTION
## 개요

- 지출 삭제 api와 service 작성

## 추가기능

-  delete 로직 추가

## 변경사항(Optional)

- CreateExpenditureRequest에 content max 50 설정
- controller에 validation  필요한 request에 @valid 어노테이션 추가
- update시 201번이 아니라  상태코드200번으로 변경
- Expenditure가 갖고 있는 fk이름 수정

## 삭제 로직

- expenditure가 있는지 확인한다.
- expenditure를 삭제한다.

- findById + delete 메서드 사용 이유
  - deleteById하면 내부 EmptyResultAccessException 따로 GlobalException 캐치하기 싫어서.
