### PR TITLE
[#24] 사용자는 지출을 조회할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
@@ -6,6 +6,7 @@ import static javax.persistence.FetchType.*;
 import static lombok.AccessLevel.*;
 
 import java.time.LocalDate;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -85,5 +86,23 @@ public class Expenditure extends BaseEntity {
 		checkArgument(amount != null, "금액은 필수입니다.");
 		checkArgument(amount >= AMOUNT_MIN && amount <= AMOUNT_MAX,
 			"입력할 수 있는 범위가 아닙니다.");
+	}
+
+	/**
+	 * TODO : naming 부자연스럽지 않은지 조언 필요
+	 * */
+	public String getCategoryName() {
+		if (Objects.isNull(this.userCategory)) {
+			return this.categoryName;
+		}
+
+		return this.userCategory.getCategory().getName();
+	}
+
+	/**
+	 * TODO : 의논 필요, 윌리엄이 userCategory 만들때 null 설정할 메서드
+	 * */
+	public void deleteUserCategory() {
+		this.userCategory = null;
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
@@ -64,7 +64,7 @@ public class ExpenditureController {
 	@DeleteMapping("/{expenditureId}")
 	public ResponseEntity<Void> deleteExpenditure(@PathVariable Long expenditureId) {
 		Long userId = 1L; // 추후 Auth로 받을 예정
-		expenditureService.deleteExpenditure(expenditureId);
+		expenditureService.deleteExpenditure(userId, expenditureId);
 
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
@@ -7,6 +7,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateExpenditureRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateExpenditureResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindExpenditureResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.UpdateExpenditureRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.service.ExpenditureService;
 
@@ -48,6 +50,15 @@ public class ExpenditureController {
 		expenditureService.updateExpenditure(userId, expenditureId, updateExpenditureRequest);
 
 		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/{expenditureId}")
+	public ResponseEntity<FindExpenditureResponse> findExpenditure(@PathVariable Long expenditureId) {
+		Long userId = 1L; // 추후 Auth로 받을 예정
+
+		FindExpenditureResponse response = expenditureService.findExpenditure(userId, expenditureId);
+
+		return ResponseEntity.ok(response);
 	}
 
 	@DeleteMapping("/{expenditureId}")

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateExpenditureResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateExpenditureResponse.java
@@ -9,7 +9,7 @@ public class CreateExpenditureResponse {
 
 	private final Long id;
 
-	public CreateExpenditureResponse(Long id) {
+	private CreateExpenditureResponse(Long id) {
 		this.id = id;
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindExpenditureResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindExpenditureResponse.java
@@ -1,0 +1,32 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import java.time.LocalDate;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
+
+public class FindExpenditureResponse {
+
+	private final LocalDate registerDate;
+
+	private final Long amount;
+
+	private final String content;
+
+	private final Long userCategoryId;
+
+	private FindExpenditureResponse(LocalDate registerDate, Long amount, String content, Long userCategoryId) {
+		this.registerDate = registerDate;
+		this.amount = amount;
+		this.content = content;
+		this.userCategoryId = userCategoryId;
+	}
+
+	public static FindExpenditureResponse of(Expenditure expenditure) {
+		return new FindExpenditureResponse(
+			expenditure.getRegisterDate(),
+			expenditure.getAmount(),
+			expenditure.getContent(),
+			expenditure.getUserCategory().getId()
+		);
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindExpenditureResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindExpenditureResponse.java
@@ -14,17 +14,14 @@ public class FindExpenditureResponse {
 
 	private final String content;
 
-	private final Long categoryId;
-
 	private final String categoryName;
 
-	private FindExpenditureResponse(Long id, LocalDate registerDate, Long amount, String content, Long categoryId,
+	private FindExpenditureResponse(Long id, LocalDate registerDate, Long amount, String content,
 		String categoryName) {
 		this.id = id;
 		this.registerDate = registerDate;
 		this.amount = amount;
 		this.content = content;
-		this.categoryId = categoryId;
 		this.categoryName = categoryName;
 	}
 
@@ -34,7 +31,6 @@ public class FindExpenditureResponse {
 			expenditure.getRegisterDate(),
 			expenditure.getAmount(),
 			expenditure.getContent(),
-			expenditure.getUserCategory().getId(),
 			expenditure.getCategoryName()
 		);
 	}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindExpenditureResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindExpenditureResponse.java
@@ -6,27 +6,36 @@ import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 
 public class FindExpenditureResponse {
 
+	private final Long id;
+
 	private final LocalDate registerDate;
 
 	private final Long amount;
 
 	private final String content;
 
-	private final Long userCategoryId;
+	private final Long categoryId;
 
-	private FindExpenditureResponse(LocalDate registerDate, Long amount, String content, Long userCategoryId) {
+	private final String categoryName;
+
+	private FindExpenditureResponse(Long id, LocalDate registerDate, Long amount, String content, Long categoryId,
+		String categoryName) {
+		this.id = id;
 		this.registerDate = registerDate;
 		this.amount = amount;
 		this.content = content;
-		this.userCategoryId = userCategoryId;
+		this.categoryId = categoryId;
+		this.categoryName = categoryName;
 	}
 
 	public static FindExpenditureResponse of(Expenditure expenditure) {
 		return new FindExpenditureResponse(
+			expenditure.getId(),
 			expenditure.getRegisterDate(),
 			expenditure.getAmount(),
 			expenditure.getContent(),
-			expenditure.getUserCategory().getId()
+			expenditure.getUserCategory().getId(),
+			expenditure.getCategoryName()
 		);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateExpenditureRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateExpenditureResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindExpenditureResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.UpdateExpenditureRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
 import com.prgrms.tenwonmoa.domain.category.Category;
@@ -54,6 +55,18 @@ public class ExpenditureService {
 		expenditure.update(userCategory, updateExpenditureRequest);
 	}
 
+	public FindExpenditureResponse findExpenditure(Long userId, Long expenditureId) {
+		User user = getUser(userId);
+		Expenditure expenditure = getExpenditure(expenditureId);
+
+		validateUser(user, expenditure.getUser());
+
+		return FindExpenditureResponse.of(expenditure);
+	}
+
+	/**
+	 * TODO : 유저가 해당 지출을 삭제할 수 있는지 검증을 추가해야 한다.
+	 * */
 	public void deleteExpenditure(Long expenditureId) {
 		Expenditure expenditure = getExpenditure(expenditureId);
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureService.java
@@ -67,8 +67,11 @@ public class ExpenditureService {
 	/**
 	 * TODO : 유저가 해당 지출을 삭제할 수 있는지 검증을 추가해야 한다.
 	 * */
-	public void deleteExpenditure(Long expenditureId) {
+	public void deleteExpenditure(Long userId, Long expenditureId) {
+		User user = getUser(userId);
 		Expenditure expenditure = getExpenditure(expenditureId);
+
+		validateUser(user, expenditure.getUser());
 
 		expenditureRepository.delete(expenditure);
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/ExpenditureTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/ExpenditureTest.java
@@ -23,11 +23,13 @@ class ExpenditureTest {
 
 	private final String content = "돈까스";
 
-	private final String categoryName = "식비";
+	private final String categoryName = "문화";
 
 	private final User user = new User("jungki111@gmail.com", "password1234!", "개발자");
 
-	private final UserCategory userCategory = new UserCategory(user, new Category("식비", CategoryType.EXPENDITURE));
+	private final Category category = new Category("식비", CategoryType.EXPENDITURE);
+
+	private final UserCategory userCategory = new UserCategory(user, category);
 
 	@Nested
 	@DisplayName("Expenditure 생성 중에서")
@@ -190,6 +192,39 @@ class ExpenditureTest {
 				.isEqualTo(otherUserCategory.getCategory().getName());
 		}
 
+	}
+
+	@Nested
+	@DisplayName("지출의 userCategory를 지우거나, category 이름을 제대로 불러오는지")
+	class DeleteExpenditureAndGetCategoryName {
+
+		private final Expenditure expenditure = new Expenditure(
+			date,
+			amount,
+			content,
+			categoryName,
+			user,
+			userCategory
+		);
+
+		@Test
+		public void 유저카테고리를_지운다() {
+			expenditure.deleteUserCategory();
+
+			assertThat(expenditure.getUserCategory()).isNull();
+		}
+
+		@Test
+		public void 유저카테고리를_지웠을때_카테고리이름을_불러온다() {
+			expenditure.deleteUserCategory();
+
+			assertThat(expenditure.getCategoryName()).isEqualTo(categoryName);
+		}
+
+		@Test
+		public void 유저카테고리를_지우지_않았을때_저장된_카테고리의_이름을_불러온다() {
+			assertThat(expenditure.getCategoryName()).isEqualTo(category.getName());
+		}
 	}
 
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
@@ -212,7 +212,7 @@ class ExpenditureServiceTest {
 
 	@Nested
 	@DisplayName("지출 삭제 중")
-	class DeleteExpenditureTEst {
+	class DeleteExpenditureTest {
 
 		@Test
 		public void 삭제하려는_지출이_없을때() {
@@ -233,5 +233,31 @@ class ExpenditureServiceTest {
 
 			verify(expenditureRepository).delete(any());
 		}
+	}
+
+	@Nested
+	@DisplayName("지출 조회 중")
+	class FindExpenditureTest {
+
+		@Test
+		public void 해당_유저가_없을경우() {
+
+		}
+
+		@Test
+		public void 해당_지출이_없을_경우() {
+
+		}
+
+		@Test
+		public void 해당_지출을_조회할_권한이_없을경우() {
+
+		}
+
+		@Test
+		public void 성공적으로_조회_할_때() {
+
+		}
+
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
@@ -18,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateExpenditureRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateExpenditureResponse;
-import com.prgrms.tenwonmoa.domain.accountbook.dto.FindExpenditureResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.UpdateExpenditureRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
 import com.prgrms.tenwonmoa.domain.category.Category;
@@ -280,15 +279,12 @@ class ExpenditureServiceTest {
 
 		private final Long expenditureId = 2L;
 
-		@Mock
-		FindExpenditureResponse mockResponse;
-
 		@Test
 		public void 해당_유저가_없을_경우() {
-			given(userRepository.findById(any()))
+			given(userRepository.findById(userId))
 				.willThrow(new NoSuchElementException(Message.USER_NOT_FOUND.getMessage()));
 
-			assertThatThrownBy(() -> expenditureService.findExpenditure(any(), expenditureId))
+			assertThatThrownBy(() -> expenditureService.findExpenditure(userId, expenditureId))
 				.isInstanceOf(NoSuchElementException.class)
 				.hasMessage(Message.USER_NOT_FOUND.getMessage());
 		}
@@ -321,7 +317,6 @@ class ExpenditureServiceTest {
 
 		@Test
 		public void 성공적으로_조회_할_때() {
-
 			given(userRepository.findById(userId))
 				.willReturn(of(user));
 
@@ -329,10 +324,7 @@ class ExpenditureServiceTest {
 				.willReturn(of(mockExpenditure));
 
 			given(mockExpenditure.getUser()).willReturn(user);
-
-			//FindExpenditureReponse에서 expenditure.getUserCategory NullPointerException 방지
-			given(mockExpenditure.getUserCategory()).willReturn(userCategory);
-
+			
 			expenditureService.findExpenditure(userId, expenditureId);
 
 			verify(expenditureRepository).findById(any());

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
@@ -136,8 +136,8 @@ class ExpenditureServiceTest {
 
 		@Test
 		public void 해당_유저가_없을_경우() {
-			given(userRepository.findById(any())).willThrow(
-				new NoSuchElementException(Message.USER_NOT_FOUND.getMessage()));
+			given(userRepository.findById(any()))
+				.willThrow(new NoSuchElementException(Message.USER_NOT_FOUND.getMessage()));
 
 			assertThatThrownBy(() -> expenditureService.updateExpenditure(any(), expenditureId, request))
 				.isInstanceOf(NoSuchElementException.class)

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
@@ -215,22 +215,58 @@ class ExpenditureServiceTest {
 	@DisplayName("지출 삭제 중")
 	class DeleteExpenditureTest {
 
+		private Long userId = 1L;
+
+		private Long expenditureId = 2L;
+
+		@Test
+		public void 해당_유저가_없을_경우() {
+			given(userRepository.findById(any()))
+				.willThrow(new NoSuchElementException(Message.USER_NOT_FOUND.getMessage()));
+
+			assertThatThrownBy(() -> expenditureService.deleteExpenditure(any(), expenditureId))
+				.isInstanceOf(NoSuchElementException.class)
+				.hasMessage(Message.USER_NOT_FOUND.getMessage());
+		}
+
 		@Test
 		public void 삭제하려는_지출이_없을때() {
+			given(userRepository.findById(userId))
+				.willReturn(of(user));
+
 			given(expenditureRepository.findById(any()))
 				.willThrow(new NoSuchElementException(Message.EXPENDITURE_NOT_FOUND.getMessage()));
 
-			assertThatThrownBy(() -> expenditureService.deleteExpenditure(any()))
+			assertThatThrownBy(() -> expenditureService.deleteExpenditure(userId, any()))
 				.isInstanceOf(NoSuchElementException.class)
 				.hasMessage(Message.EXPENDITURE_NOT_FOUND.getMessage());
 		}
 
 		@Test
-		public void 지출을_성공적으로_삭제_할_때() {
-			given(expenditureRepository.findById(any()))
-				.willReturn(of(expenditure));
+		public void 해당_지출에_대한_삭제권한이_없을때() {
+			given(userRepository.findById(userId))
+				.willReturn(of(user));
 
-			expenditureService.deleteExpenditure(any());
+			given(expenditureRepository.findById(expenditureId))
+				.willReturn(of(mockExpenditure));
+
+			assertThatThrownBy(() -> expenditureService.deleteExpenditure(userId, expenditureId))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage(Message.EXPENDITURE_NO_AUTHENTICATION.getMessage());
+
+		}
+
+		@Test
+		public void 지출을_성공적으로_삭제_할_때() {
+			given(userRepository.findById(userId))
+				.willReturn(of(user));
+
+			given(expenditureRepository.findById(expenditureId))
+				.willReturn(of(mockExpenditure));
+
+			given(mockExpenditure.getUser()).willReturn(user);
+
+			expenditureService.deleteExpenditure(userId, expenditureId);
 
 			verify(expenditureRepository).delete(any());
 		}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/ExpenditureServiceTest.java
@@ -324,7 +324,6 @@ class ExpenditureServiceTest {
 				.willReturn(of(mockExpenditure));
 
 			given(mockExpenditure.getUser()).willReturn(user);
-			
 			expenditureService.findExpenditure(userId, expenditureId);
 
 			verify(expenditureRepository).findById(any());


### PR DESCRIPTION
## 추가기능

## 지출 상세 조회
 
- 응답 dto 작성
 - controller와 service 작성

## 서비스 로직
 
- 해당 유저가 있는지
 - 지출이 있는지
 - 해당 유저가 지출을 조회할 권한이 있는지
 - 이후 조회 
- 조회할 때 카테고리 이름은 category table까지 들어가서 가져오거나
- userCategory가 없으면 필드에 categoryName

## 변경사항(Optional)

- 기존에 지출 삭제에서 유저권한없이 로직을 수행했음
- 유저가 해당 지출을 삭제할 권한을 체크
