### PR TITLE
[#31] 사용자는 수입을 등록할 수 있다. - Controller

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+    // Lombok
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 test {
@@ -168,7 +171,6 @@ clean {
     delete file('src/main/generated')
 }
 
-// custom task
 task copyDocument(type: Copy) {
     dependsOn asciidoctor
     from file("build/docs/asciidoc")

--- a/docs/income.adoc
+++ b/docs/income.adoc
@@ -1,0 +1,20 @@
+:hardbreaks:
+ifndef::snippets[]
+:snippets: ../../../target/generated-snippets
+endif::[]
+
+== 수입
+
+### 수입등록
+
+.Request
+include::{snippets}/income-create/http-request.adoc[]
+include::{snippets}/income-create/request-fields.adoc[]
+
+.Response
+include::{snippets}/income-create/http-response.adoc[]
+
+.Exception
+include::{snippets}/income-create-fail/http-response.adoc[]
+
+

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateIncomeRequest;
-import com.prgrms.tenwonmoa.domain.accountbook.service.AccountBookService;
+import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeTotalService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,13 +20,13 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/incomes")
 public class IncomeController {
 
-	private final AccountBookService accountBookService;
+	private final IncomeTotalService incomeTotalService;
 	private static final String LOCATION_PREFIX = "/api/v1/incomes/";
 
 	@PostMapping
 	public ResponseEntity<Long> createIncome(@RequestBody @Valid CreateIncomeRequest request) {
 		Long userId = 1L; // TODO user 정보를 시큐리티 컨텍스에서 찾도록 변경한다.
-		Long createdId = accountBookService.createIncome(userId, request);
+		Long createdId = incomeTotalService.createIncome(userId, request);
 
 		String redirectUri = new StringBuilder(LOCATION_PREFIX).append(createdId).toString();
 		return ResponseEntity.created(URI.create(redirectUri)).body(createdId);

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
@@ -1,0 +1,35 @@
+package com.prgrms.tenwonmoa.domain.accountbook.controller;
+
+import java.net.URI;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.accountbook.service.AccountBookService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/incomes")
+public class IncomeController {
+
+	private final AccountBookService accountBookService;
+	private static final String LOCATION_PREFIX = "/api/v1/incomes/";
+
+	@PostMapping
+	public ResponseEntity<Long> createIncome(@RequestBody @Valid CreateIncomeRequest request) {
+		Long userId = 1L; // TODO user 정보를 시큐리티 컨텍스에서 찾도록 변경한다.
+		Long createdId = accountBookService.createIncome(userId, request);
+
+		String redirectUri = new StringBuilder(LOCATION_PREFIX).append(createdId).toString();
+		return ResponseEntity.created(URI.create(redirectUri)).body(createdId);
+	}
+
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateIncomeRequest.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CreateIncomeRequest.java
@@ -11,6 +11,9 @@ import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
 
+import lombok.Getter;
+
+@Getter
 public class CreateIncomeRequest {
 	@NotNull
 	private final LocalDate registerDate;
@@ -41,9 +44,5 @@ public class CreateIncomeRequest {
 			user,
 			userCategory
 		);
-	}
-
-	public Long getUserCategoryId() {
-		return userCategoryId;
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler {
 
 	// 400 : NotFound - 잘못된 요청
 	@ExceptionHandler(NoSuchElementException.class)
-	public ResponseEntity<ErrorResponse> handleNotFoundException(HttpRequestMethodNotSupportedException exception) {
+	public ResponseEntity<ErrorResponse> handleNotFoundException(NoSuchElementException exception) {
 		log.error(exception.getMessage(), exception);
 		ErrorResponse errorResponse = new ErrorResponse(List.of(exception.getMessage()), BAD_REQUEST.value());
 		return ResponseEntity
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(AlreadyExistException.class)
-	public ResponseEntity<ErrorResponse> handleAlreadyExistException(HttpRequestMethodNotSupportedException exception) {
+	public ResponseEntity<ErrorResponse> handleAlreadyExistException(AlreadyExistException exception) {
 		log.error(exception.getMessage(), exception);
 		ErrorResponse errorResponse = new ErrorResponse(List.of(exception.getMessage()), BAD_REQUEST.value());
 		return ResponseEntity

--- a/src/test/java/com/prgrms/tenwonmoa/common/documentdto/CreateIncomeRequestDoc.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/documentdto/CreateIncomeRequestDoc.java
@@ -1,0 +1,40 @@
+package com.prgrms.tenwonmoa.common.documentdto;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum CreateIncomeRequestDoc {
+	REGISTER_DATE(STRING, "registerDate", "수입 등록 날짜"),
+	AMOUNT(NUMBER, "amount", "수입 금액"),
+	CONTENT(STRING, "content", "내용"),
+	USER_CATEGORY_ID(NUMBER, "userCategoryId", "유저 카테고리 ID");
+
+	private final JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField())
+			.type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> fieldDescriptors() {
+		return List.of(
+			REGISTER_DATE.getFieldDescriptor(),
+			AMOUNT.getFieldDescriptor(),
+			CONTENT.getFieldDescriptor(),
+			USER_CATEGORY_ID.getFieldDescriptor()
+		);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/documentdto/ErrorResponseDoc.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/documentdto/ErrorResponseDoc.java
@@ -1,0 +1,36 @@
+package com.prgrms.tenwonmoa.common.documentdto;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorResponseDoc {
+	MESSAGES(ARRAY, "messages", "예외 메시지"),
+	STATUS(NUMBER, "status", "에러 코드");
+
+	private final JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField())
+			.type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> fieldDescriptors() {
+		return List.of(
+			MESSAGES.getFieldDescriptor(),
+			STATUS.getFieldDescriptor()
+		);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
@@ -67,8 +66,7 @@ class IncomeControllerTest {
 				requestFields(
 					CreateIncomeRequestDoc.fieldDescriptors()
 				)
-			))
-			.andDo(print());
+			));
 	}
 
 	@Test
@@ -83,7 +81,6 @@ class IncomeControllerTest {
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-create-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
-			)))
-			.andDo(print());
+			)));
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -40,7 +40,7 @@ class IncomeControllerTest {
 	@MockBean
 	private AccountBookService accountBookService;
 
-	private static final String LOCATION_PREFIX = "/api/v1/incomes/";
+	private static final String INCOME_CREATE_URI = "/api/v1/incomes/";
 
 	private CreateIncomeRequest request = new CreateIncomeRequest(
 		LocalDate.now(),
@@ -61,7 +61,7 @@ class IncomeControllerTest {
 		)
 			.andExpect(status().isCreated())
 			.andExpect(content().string(String.valueOf(createdId)))
-			.andExpect(redirectedUrl(LOCATION_PREFIX + createdId))
+			.andExpect(redirectedUrl(INCOME_CREATE_URI + createdId))
 			.andDo(document("income-create",
 				requestFields(
 					CreateIncomeRequestDoc.fieldDescriptors()

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.tenwonmoa.common.documentdto.CreateIncomeRequestDoc;
 import com.prgrms.tenwonmoa.common.documentdto.ErrorResponseDoc;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateIncomeRequest;
-import com.prgrms.tenwonmoa.domain.accountbook.service.AccountBookService;
+import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeTotalService;
 
 @WebMvcTest(controllers = IncomeController.class)
 @AutoConfigureRestDocs
@@ -38,7 +38,7 @@ class IncomeControllerTest {
 	private ObjectMapper objectMapper;
 
 	@MockBean
-	private AccountBookService accountBookService;
+	private IncomeTotalService incomeTotalService;
 
 	private static final String INCOME_CREATE_URI = "/api/v1/incomes/";
 
@@ -52,7 +52,7 @@ class IncomeControllerTest {
 	@Test
 	void 수입_등록_성공() throws Exception {
 		Long createdId = 1L;
-		given(accountBookService.createIncome(any(Long.class), any(CreateIncomeRequest.class)))
+		given(incomeTotalService.createIncome(any(Long.class), any(CreateIncomeRequest.class)))
 			.willReturn(createdId);
 
 		mockMvc.perform(post("/api/v1/incomes")
@@ -71,7 +71,7 @@ class IncomeControllerTest {
 
 	@Test
 	void 수입_등록_실패() throws Exception {
-		given(accountBookService.createIncome(any(Long.class), any(CreateIncomeRequest.class)))
+		given(incomeTotalService.createIncome(any(Long.class), any(CreateIncomeRequest.class)))
 			.willThrow(new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
 
 		mockMvc.perform(post("/api/v1/incomes")

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -1,0 +1,89 @@
+package com.prgrms.tenwonmoa.domain.accountbook.controller;
+
+import static com.prgrms.tenwonmoa.exception.message.Message.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.tenwonmoa.common.documentdto.CreateIncomeRequestDoc;
+import com.prgrms.tenwonmoa.common.documentdto.ErrorResponseDoc;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.accountbook.service.AccountBookService;
+
+@WebMvcTest(controllers = IncomeController.class)
+@AutoConfigureRestDocs
+@MockBean(JpaMetamodelMappingContext.class)
+@DisplayName("수입 컨트롤러 테스트")
+class IncomeControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private AccountBookService accountBookService;
+
+	private static final String LOCATION_PREFIX = "/api/v1/incomes/";
+
+	private CreateIncomeRequest request = new CreateIncomeRequest(
+		LocalDate.now(),
+		1000L,
+		"content",
+		1L
+	);
+
+	@Test
+	void 수입_등록_성공() throws Exception {
+		Long createdId = 1L;
+		given(accountBookService.createIncome(any(Long.class), any(CreateIncomeRequest.class)))
+			.willReturn(createdId);
+
+		mockMvc.perform(post("/api/v1/incomes")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request))
+		)
+			.andExpect(status().isCreated())
+			.andExpect(content().string(String.valueOf(createdId)))
+			.andExpect(redirectedUrl(LOCATION_PREFIX + createdId))
+			.andDo(document("income-create",
+				requestFields(
+					CreateIncomeRequestDoc.fieldDescriptors()
+				)
+			))
+			.andDo(print());
+	}
+
+	@Test
+	void 수입_등록_실패() throws Exception {
+		given(accountBookService.createIncome(any(Long.class), any(CreateIncomeRequest.class)))
+			.willThrow(new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
+
+		mockMvc.perform(post("/api/v1/incomes")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request))
+		)
+			.andExpect(status().isBadRequest())
+			.andDo(document("income-create-fail", responseFields(
+				ErrorResponseDoc.fieldDescriptors()
+			)))
+			.andDo(print());
+	}
+}


### PR DESCRIPTION
## 개요
- 수입등록 컨트롤러 구현
- 통합테스트 미구현

## 추가기능
- 수입등록 api 추가
- 관련 restdocs 추가

## 변경사항(Optional)
- GlobalExceptionHandler 예외 타입 변경
  - 모든 메서드에서 HttpRequestMethodNotSupportedException로 처리되고 있었음.

## 사용방법(Optional)
![image](https://user-images.githubusercontent.com/26343023/181288414-fbb73ab7-42c3-4788-8d7d-fb5753567864.png)
