### PR TITLE
[#43] AccountBookService 이름 변경

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class AccountBookService {
+public class IncomeTotalService {
 	private final UserService userService;
 	private final UserCategoryService userCategoryService;
 	private final IncomeService incomeService;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
@@ -25,7 +25,7 @@ import com.prgrms.tenwonmoa.exception.message.Message;
 
 @DisplayName("가계부 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
-class AccountBookServiceTest {
+class IncomeTotalServiceTest {
 
 	@Mock
 	private UserService userService;
@@ -34,7 +34,7 @@ class AccountBookServiceTest {
 	@Mock
 	private IncomeService incomeService;
 	@InjectMocks
-	private AccountBookService accountBookService;
+	private IncomeTotalService accountBookService;
 
 	private final Income income = createIncome();
 	private final UserCategory userCategory = income.getUsercategory();


### PR DESCRIPTION
## 변경 전
- 수입등록을 개발하며 accountbook 도메인의 통합 서비스로 AccountBookService를 정의했다.
  - 루체의 AccountBookService가 수입을 생성하는게 어색하다라는 의견
  - AccountBookService가 수입을 생성하는게 맞는가 ?

## 변경 후
- AccountBookService의 이름을 변경여 수입에서 관리되는 통합서비스로 사용한다.
- AccountBook도메인의 서비스는 함께 정의한다.