### PR TITLE
[#45] 사용자는 일일 내역을 조회 중 일별 수입과 지출을 불러오는 쿼리 작성

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/config/QueryDslConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/QueryDslConfig.java
@@ -1,6 +1,7 @@
 package com.prgrms.tenwonmoa.config;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,8 +11,11 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 @Configuration
 public class QueryDslConfig {
 
+	@PersistenceContext
+	private EntityManager entityManager;
+
 	@Bean
-	public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+	public JPAQueryFactory jpaQueryFactory() {
 		return new JPAQueryFactory(entityManager);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureCustomRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureCustomRepository.java
@@ -1,0 +1,11 @@
+package com.prgrms.tenwonmoa.domain.accountbook.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
+
+public interface ExpenditureCustomRepository {
+
+	List<Expenditure> findByRegisterDate(Long userId, LocalDate localDate);
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 
-public interface ExpenditureRepository extends JpaRepository<Expenditure, Long> {
+public interface ExpenditureRepository extends JpaRepository<Expenditure, Long>, ExpenditureCustomRepository {
 
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepositoryImpl.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.prgrms.tenwonmoa.domain.accountbook.repository;
+
+import static com.prgrms.tenwonmoa.domain.accountbook.QExpenditure.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ExpenditureRepositoryImpl implements ExpenditureCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Expenditure> findByRegisterDate(Long userId, LocalDate localDate) {
+
+		List<Expenditure> expenditures = queryFactory.select(expenditure)
+			.from(expenditure)
+			.where(
+				expenditure.user.id.eq(userId),
+				expenditure.registerDate.eq(localDate)
+			)
+			.orderBy(expenditure.createdAt.desc())
+			.fetch();
+
+		return expenditures;
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/common/BaseEntity.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/common/BaseEntity.java
@@ -19,7 +19,7 @@ import lombok.Getter;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-@EqualsAndHashCode
+@EqualsAndHashCode(of = "id")
 public class BaseEntity {
 
 	@Id

--- a/src/main/java/com/prgrms/tenwonmoa/domain/common/BaseEntity.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/common/BaseEntity.java
@@ -2,11 +2,15 @@ package com.prgrms.tenwonmoa.domain.common;
 
 import static javax.persistence.GenerationType.*;
 
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import lombok.EqualsAndHashCode;
@@ -21,4 +25,8 @@ public class BaseEntity {
 	@Id
 	@GeneratedValue(strategy = AUTO)
 	private Long id;
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
 }

--- a/src/test/java/com/prgrms/tenwonmoa/common/DatabaseCleaner.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/DatabaseCleaner.java
@@ -1,0 +1,43 @@
+package com.prgrms.tenwonmoa.common;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Table;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class DatabaseCleaner implements InitializingBean {
+
+	@PersistenceContext
+	private EntityManager em;
+
+	private List<String> tables;
+
+	@Override
+	public void afterPropertiesSet() {
+		tables = em.getMetamodel().getEntities().stream()
+			.filter(entityType -> entityType.getJavaType().getAnnotation(Entity.class) != null)
+			.map(entityType -> {
+				Optional<Table> atTable = Optional.ofNullable(entityType.getJavaType().getAnnotation(Table.class));
+				return atTable.isPresent() ? atTable.get().name() : entityType.getName();
+			})
+			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public void cleanUp() {
+		em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+		for (String table : tables) {
+			em.createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
+		}
+		em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/RepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/RepositoryTest.java
@@ -1,0 +1,20 @@
+package com.prgrms.tenwonmoa.common;
+
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import com.prgrms.tenwonmoa.common.annotation.CustomDataJpaTest;
+
+@Disabled
+@CustomDataJpaTest
+public class RepositoryTest {
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	protected <T> T save(T entity) {
+		entityManager.persist(entity);
+		return entity;
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/annotation/CustomDataJpaTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/annotation/CustomDataJpaTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.prgrms.tenwonmoa.common.util.BeanUtil;
 import com.prgrms.tenwonmoa.config.TestConfig;
 
 @Target(ElementType.TYPE)
@@ -17,6 +18,6 @@ import com.prgrms.tenwonmoa.config.TestConfig;
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(TestConfig.class)
+@Import({TestConfig.class, BeanUtil.class})
 public @interface CustomDataJpaTest {
 }

--- a/src/test/java/com/prgrms/tenwonmoa/common/util/BeanUtil.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/util/BeanUtil.java
@@ -1,0 +1,21 @@
+package com.prgrms.tenwonmoa.common.util;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BeanUtil implements ApplicationContextAware {
+
+	private static ApplicationContext applicationContext;
+
+	public static <T> T getBean(Class<T> clazz) {
+		return applicationContext.getBean(clazz);
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		BeanUtil.applicationContext = applicationContext;
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.prgrms.tenwonmoa.domain.accountbook.repository;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.prgrms.tenwonmoa.common.RepositoryTest;
+import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.user.User;
+
+@DisplayName("Expenditure(지출) 레포지토리 테스트")
+class ExpenditureRepositoryTest extends RepositoryTest {
+
+	@Autowired
+	private ExpenditureRepository expenditureRepository;
+
+	private User user;
+
+	private Category category;
+
+	private UserCategory userCategory;
+
+	@BeforeEach
+	void setup() {
+		user = save(createUser());
+		category = save(createCategory());
+		userCategory = save(new UserCategory(user, category));
+	}
+
+	@Nested
+	@DisplayName("지출에 대한 일별 쿼리 중")
+	class ExpenditureDayQuery {
+
+		@Test
+		public void 사용자에대해_지정한_날짜에대한_결과를_리스트로_반환한다() {
+			createExpenditures(10);
+
+			List<Expenditure> expenditures = expenditureRepository.findByRegisterDate(user.getId(), LocalDate.now());
+			assertThat(expenditures.size()).isEqualTo(10);
+		}
+
+	}
+
+	private void createExpenditures(int count) {
+		for (int i = 0; i < count; i++) {
+			expenditureRepository.save(
+				new Expenditure(
+					LocalDate.now(),
+					10000L + i,
+					"내용" + i,
+					category.getName(),
+					user,
+					userCategory
+				)
+			);
+		}
+	}
+}


### PR DESCRIPTION
## 추가기능

### db cleaner와 beanutils 작성

- db cleaner는 참조 무결성 제약 해제하기 위해서
- beanutils 애플리케이션 컨텍스트 문제 해결인데 정확히 알아봐야함...
- 일별 지출을 리스트로 조회하는 쿼리 작성(사용자가 갖고있는 지출에서 7월 20일에 해당하는 지출을 조회한다.) 
- BaseEntity에 created_at

## 사용방법(Optional)

- 앞으로 Repository Test진행하실때 Repository.class 상속받아서 사용하시면 됩니다.
- 추후 save 메서드 통해서 공통 메서드 사용
