### PR TITLE
[#42] 수입 상세조회 구현

### DIFF
--- a/docs/income.adoc
+++ b/docs/income.adoc
@@ -17,4 +17,15 @@ include::{snippets}/income-create/http-response.adoc[]
 .Exception
 include::{snippets}/income-create-fail/http-response.adoc[]
 
+### 수입 상세조회
+
+.Request
+include::{snippets}/income-find-by-id/http-request.adoc[]
+
+.Response
+include::{snippets}/income-find-by-id/http-response.adoc[]
+
+.Exception
+include::{snippets}/income-find-by-id-fail/http-response.adoc[]
+
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
@@ -5,12 +5,16 @@ import java.net.URI;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindIncomeResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeService;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeTotalService;
 
 import lombok.RequiredArgsConstructor;
@@ -20,8 +24,10 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/incomes")
 public class IncomeController {
 
-	private final IncomeTotalService incomeTotalService;
 	private static final String LOCATION_PREFIX = "/api/v1/incomes/";
+
+	private final IncomeTotalService incomeTotalService;
+	private final IncomeService incomeService;
 
 	@PostMapping
 	public ResponseEntity<Long> createIncome(@RequestBody @Valid CreateIncomeRequest request) {
@@ -32,4 +38,9 @@ public class IncomeController {
 		return ResponseEntity.created(URI.create(redirectUri)).body(createdId);
 	}
 
+	@GetMapping("/{incomeId}")
+	public FindIncomeResponse findIncome(@PathVariable Long incomeId) {
+		Long userId = 1L; // TODO user 정보를 시큐리티 컨텍스에서 찾도록 변경한다.
+		return incomeService.findIncome(incomeId, userId);
+	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindIncomeResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindIncomeResponse.java
@@ -1,0 +1,40 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import java.time.LocalDate;
+
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+
+import lombok.Getter;
+
+@Getter
+public class FindIncomeResponse {
+
+	private final Long id;
+
+	private final LocalDate registerDate;
+
+	private final Long amount;
+
+	private final String content;
+
+	private final String categoryName;
+
+	public FindIncomeResponse(Long id, LocalDate registerDate, Long amount, String content,
+		String categoryName) {
+		this.id = id;
+		this.registerDate = registerDate;
+		this.amount = amount;
+		this.content = content;
+		this.categoryName = categoryName;
+	}
+
+	public static FindIncomeResponse of(Income income) {
+		return new FindIncomeResponse(
+			income.getId(),
+			income.getRegisterDate(),
+			income.getAmount(),
+			income.getContent(),
+			income.getCategoryName()
+		);
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
@@ -1,9 +1,11 @@
 package com.prgrms.tenwonmoa.domain.accountbook.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 
 public interface IncomeRepository extends JpaRepository<Income, Long> {
-
+	Optional<Income> findByIdAndUserId(Long incomeId, Long userId);
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
@@ -1,9 +1,14 @@
 package com.prgrms.tenwonmoa.domain.accountbook.service;
 
+import static com.prgrms.tenwonmoa.exception.message.Message.*;
+
+import java.util.NoSuchElementException;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -18,5 +23,11 @@ public class IncomeService {
 	@Transactional
 	public Long save(Income income) {
 		return incomeRepository.save(income).getId();
+	}
+
+	public FindIncomeResponse findIncome(Long incomeId, Long userId) {
+		Income findIncome = incomeRepository.findByIdAndUserId(incomeId, userId)
+			.orElseThrow(() -> new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
+		return FindIncomeResponse.of(findIncome);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
@@ -25,6 +25,7 @@ public enum Message {
 	// 수입
 	INVALID_CONTENT_ERR_MSG(MessageFormat.format("내용은 {0}글자 까지만 가능합니다.", CONTENT_MAX)),
 	INVALID_AMOUNT_ERR_MSG(MessageFormat.format("입력 가능 범위는 {0}~{1}입니다.", AMOUNT_MIN, AMOUNT_MAX)),
+	INCOME_NOT_FOUND("수입 정보가 존재하지 않습니다."),
 
 	// 유저
 	NOT_NULL_EMAIL("이메일은 필수입니다."),

--- a/src/test/java/com/prgrms/tenwonmoa/common/RepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/RepositoryTest.java
@@ -14,7 +14,9 @@ public class RepositoryTest {
 	private TestEntityManager entityManager;
 
 	protected <T> T save(T entity) {
-		entityManager.persist(entity);
-		return entity;
+		T persist = entityManager.persist(entity);
+		entityManager.flush();
+		entityManager.clear();
+		return persist;
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindIncomeResponseDoc.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindIncomeResponseDoc.java
@@ -1,0 +1,42 @@
+package com.prgrms.tenwonmoa.common.documentdto;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FindIncomeResponseDoc {
+	ID(NUMBER, "id", "수입 ID"),
+	REGISTER_DATE(STRING, "registerDate", "수입 등록 날짜"),
+	AMOUNT(NUMBER, "amount", "수입 금액"),
+	CONTENT(STRING, "content", "내용"),
+	CATEGORY_NAME(STRING, "categoryName", "카테고리 이름");
+
+	private final JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField())
+			.type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> fieldDescriptors() {
+		return List.of(
+			ID.getFieldDescriptor(),
+			REGISTER_DATE.getFieldDescriptor(),
+			AMOUNT.getFieldDescriptor(),
+			CONTENT.getFieldDescriptor(),
+			CATEGORY_NAME.getFieldDescriptor()
+		);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/fixture/Fixture.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/fixture/Fixture.java
@@ -1,6 +1,7 @@
 package com.prgrms.tenwonmoa.common.fixture;
 
 import java.time.LocalDate;
+import java.util.Random;
 
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.category.Category;
@@ -12,8 +13,23 @@ public final class Fixture {
 	private Fixture() {
 	}
 
+	private static String makeUserName() {
+		int leftLimit = 'a';
+		int rightLimit = 'z';
+		int targetStringLength = 10;
+		Random random = new Random();
+		StringBuilder buffer = new StringBuilder(targetStringLength);
+		for (int i = 0; i < targetStringLength; i++) {
+			int randomLimitedInt = leftLimit + (int)
+				(random.nextFloat() * (rightLimit - leftLimit + 1));
+			buffer.append((char) randomLimitedInt);
+		}
+		return buffer.toString();
+	}
+
 	public static User createUser() {
-		return new User("test@gmail.com", "123456789", "testuser");
+		String userName = makeUserName();
+		return new User(userName + "@gmail.com", "123456789", userName);
 	}
 
 	public static Category createCategory() {

--- a/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
@@ -1,0 +1,50 @@
+package com.prgrms.tenwonmoa.common.fixture;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+
+import java.time.LocalDate;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.prgrms.tenwonmoa.common.RepositoryTest;
+import com.prgrms.tenwonmoa.common.annotation.CustomDataJpaTest;
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.CategoryType;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.category.repository.CategoryRepository;
+import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+public class RepositoryFixture extends RepositoryTest {
+
+	public User saveUser() {
+		return save(createUser());
+	}
+
+	public Category saveCategory() {
+		return save(createCategory());
+	}
+
+	public UserCategory saveUserCategory() {
+		return save(new UserCategory(saveUser(), saveCategory()));
+	}
+
+	public Income saveIncome() {
+		UserCategory userCategory = saveUserCategory();
+		return save(new Income(LocalDate.now(),
+			1000L,
+			"content",
+			userCategory.getCategory().getName(),
+			userCategory.getUser(),
+			userCategory));
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.prgrms.tenwonmoa.domain.accountbook.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.prgrms.tenwonmoa.common.fixture.RepositoryFixture;
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.user.User;
+
+@DisplayName("수입 Repository 테스트")
+class IncomeRepositoryTest extends RepositoryFixture {
+
+	@Autowired
+	private IncomeRepository incomeRepository;
+
+	@Test
+	void 유저아이디와_수입아이디로_조회_성공() {
+		// given
+		Income income = saveIncome();
+		User user = income.getUser();
+
+		// when
+		Optional<Income> findIncome = incomeRepository.findByIdAndUserId(income.getId(), user.getId());
+
+		// then
+		assertThat(findIncome.isPresent());
+		Income getIncome = findIncome.get();
+		assertAll(
+			() -> assertThat(getIncome.getId()).isEqualTo(income.getId()),
+			() -> assertThat(getIncome.getUser().getId()).isEqualTo(user.getId())
+		);
+	}
+
+	@Test
+	void 로그인한아이디가_다른계정의_수입을_조회할수없다() {
+		// given
+		Income loginIncome = saveIncome();
+		Income otherIncome = saveIncome();
+
+		User loginUser = loginIncome.getUser();
+		// when
+		Optional<Income> findIncome = incomeRepository.findByIdAndUserId(otherIncome.getId(), loginUser.getId());
+
+		// then
+		assertThat(findIncome).isEmpty();
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,7 +16,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+import com.prgrms.tenwonmoa.exception.message.Message;
 
 @DisplayName("수입 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -35,5 +40,33 @@ class IncomeServiceTest {
 			() -> assertThat(savedId).isEqualTo(income.getId()),
 			() -> verify(incomeRepository).save(income)
 		);
+	}
+
+	@Test
+	void 아이디로_수입조회_성공() {
+		Long incomeId = 1L;
+		Long userId = 1L;
+
+		given(incomeRepository.findByIdAndUserId(any(Long.class), any(Long.class))).willReturn(Optional.of(income));
+
+		FindIncomeResponse findIncomeResponse = incomeService.findIncome(incomeId, userId);
+		assertAll(
+			() -> assertThat(findIncomeResponse.getId()).isEqualTo(income.getId()),
+			() -> assertThat(findIncomeResponse.getRegisterDate()).isEqualTo(income.getRegisterDate()),
+			() -> assertThat(findIncomeResponse.getAmount()).isEqualTo(income.getAmount()),
+			() -> assertThat(findIncomeResponse.getContent()).isEqualTo(income.getContent()),
+			() -> assertThat(findIncomeResponse.getCategoryName()).isEqualTo(income.getCategoryName()),
+			() -> verify(incomeRepository).findByIdAndUserId(incomeId, userId)
+		);
+	}
+
+	@Test
+	void 아이디로_조회_수입정보가없으면_실패() {
+		given(incomeRepository.findByIdAndUserId(any(Long.class), any(Long.class))).willThrow(
+			new NoSuchElementException(Message.INCOME_NOT_FOUND.getMessage()));
+
+		assertThatThrownBy(() -> incomeRepository.findByIdAndUserId(1L, 1L))
+			.isInstanceOf(NoSuchElementException.class)
+			.hasMessage(Message.INCOME_NOT_FOUND.getMessage());
 	}
 }


### PR DESCRIPTION
## 개요
- 수입 상세 조회 API 구현

## 추가기능
- `/api/v1/incomes`
- 상세조회 서비스 구현

## 변경사항(Optional)
- RepositoryTest 에서 flush, clear를 추가했습니다. 기존 구조에서는 영속성 컨텍스트가 비워지지 않기 때문에 select 쿼리가 조회되지 않는 이슈가 존재했습니다.
  - 반환 값도, 전달된 entity가 아닌, 영속화된 entity를 받도록 변경했습니다.
- Fixture에서 User만들 때 email이 unique라서 여러번 호출해서 save를 테스트하는경우 문제가 발생했습니다.
  - 따라서 새로운 email을 가질수있도록 조금 변경했습니다. 사용방법은 기존과 동일합니다.

## 사용방법(Optional)
- 사용자는 수입에대한 상세를 조회할 수 있다.
  - 현재 어플리케이션에서는 수정을 위해 수입상세데이터를 조회하게 됨.

- 다른 사용자의 데이터는 조회할 수 없다.
  - 1번 유저가 URI로 자신이 가지고 있지 않은 데이터를 요청하더라도 반환되지 않는다.
  - 로그인 된 id를 조회조건에 포함시키기 때문이다.

## 기타
![image](https://user-images.githubusercontent.com/26343023/181567536-f9f23b86-5620-4f0a-a440-a7bd0a95bd42.png)



