### PR TITLE
[#75] 수입 삭제 & 수입관련 서비스 유효성 검사로직 추가

### DIFF
--- a/docs/income.adoc
+++ b/docs/income.adoc
@@ -39,3 +39,11 @@ include::{snippets}/income-update/http-response.adoc[]
 .Exception
 include::{snippets}/income-update-fail/http-response.adoc[]
 
+
+=== 수입 삭제
+
+.Request
+include::{snippets}/income-delete/http-request.adoc[]
+
+.Response
+include::{snippets}/income-delete/http-response.adoc[]

--- a/docs/income.adoc
+++ b/docs/income.adoc
@@ -47,3 +47,8 @@ include::{snippets}/income-delete/http-request.adoc[]
 
 .Response
 include::{snippets}/income-delete/http-response.adoc[]
+
+=== 수입 권한없음
+
+.Response
+include::{snippets}/income-forbidden/http-response.adoc[]

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
@@ -19,6 +19,8 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.UpdateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeService;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeTotalService;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,11 +33,17 @@ public class IncomeController {
 
 	private final IncomeTotalService incomeTotalService;
 	private final IncomeService incomeService;
+	private final UserService userService;
+
+	// TODO 로그인이 완성되면 AuthenticationManager를 통해가져오도록 변경한다. 그전까지 임시로 사용
+	private User authenticateUserTemp() {
+		Long userId = 1L;
+		return userService.findById(userId);
+	}
 
 	@PostMapping
 	public ResponseEntity<Long> createIncome(@RequestBody @Valid CreateIncomeRequest request) {
-		Long userId = 1L; // TODO user 정보를 시큐리티 컨텍스트에서 찾도록 변경한다.
-		Long createdId = incomeTotalService.createIncome(userId, request);
+		Long createdId = incomeTotalService.createIncome(authenticateUserTemp(), request);
 
 		String redirectUri = LOCATION_PREFIX + createdId;
 		return ResponseEntity.created(URI.create(redirectUri)).body(createdId);
@@ -43,23 +51,20 @@ public class IncomeController {
 
 	@GetMapping("/{incomeId}")
 	public FindIncomeResponse findIncome(@PathVariable Long incomeId) {
-		Long userId = 1L; // TODO user 정보를 시큐리티 컨텍스트에서 찾도록 변경한다.
-		return incomeService.findIncome(incomeId, userId);
+		return incomeService.findIncome(incomeId, authenticateUserTemp());
 	}
 
 	@PutMapping("/{incomeId}")
 	public ResponseEntity<Void> updateIncome(@PathVariable Long incomeId,
 		@RequestBody @Valid UpdateIncomeRequest updateIncomeRequest
 	) {
-		Long userId = 1L; // TODO user 정보를 시큐리티 컨텍스트에서 찾도록 변경한다.
-		incomeTotalService.updateIncome(userId, incomeId, updateIncomeRequest);
+		incomeTotalService.updateIncome(authenticateUserTemp(), incomeId, updateIncomeRequest);
 		return ResponseEntity.noContent().build();
 	}
 
 	@DeleteMapping("/{incomeId}")
 	public ResponseEntity<Void> deleteIncome(@PathVariable Long incomeId) {
-		Long userId = 1L; // TODO user 정보를 시큐리티 컨텍스트에서 찾도록 변경한다.
-		incomeService.deleteIncome(incomeId, userId);
+		incomeTotalService.deleteIncome(incomeId, authenticateUserTemp());
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,6 +53,13 @@ public class IncomeController {
 	) {
 		Long userId = 1L; // TODO user 정보를 시큐리티 컨텍스트에서 찾도록 변경한다.
 		incomeTotalService.updateIncome(userId, incomeId, updateIncomeRequest);
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping("/{incomeId}")
+	public ResponseEntity<Void> deleteIncome(@PathVariable Long incomeId) {
+		Long userId = 1L; // TODO user 정보를 시큐리티 컨텍스트에서 찾도록 변경한다.
+		incomeService.deleteIncome(incomeId, userId);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
@@ -15,4 +15,8 @@ public interface IncomeRepository extends JpaRepository<Income, Long> {
 	@Query("update Income i set i.userCategory = null "
 		+ "where i.userCategory.id = :userCategoryId")
 	void updateUserCategoryAsNull(Long userCategoryId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM Income i WHERE i.id = :incomeId AND i.user.id = :userId")
+	void deleteByIdAndUserId(Long incomeId, Long userId);
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
@@ -1,7 +1,5 @@
 package com.prgrms.tenwonmoa.domain.accountbook.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,14 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 
 public interface IncomeRepository extends JpaRepository<Income, Long> {
-	Optional<Income> findByIdAndUserId(Long incomeId, Long userId);
-
 	@Modifying(clearAutomatically = true)
 	@Query("update Income i set i.userCategory = null "
 		+ "where i.userCategory.id = :userCategoryId")
 	void updateUserCategoryAsNull(Long userCategoryId);
 
 	@Modifying(clearAutomatically = true)
-	@Query("DELETE FROM Income i WHERE i.id = :incomeId AND i.user.id = :userId")
-	void deleteByIdAndUserId(Long incomeId, Long userId);
+	@Query("DELETE FROM Income i WHERE i.id = :id")
+	void deleteById(Long id);
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
@@ -36,6 +36,10 @@ public class IncomeService {
 			.orElseThrow(() -> new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
 	}
 
+	public void deleteIncome(Long incomeId, Long userId) {
+		incomeRepository.deleteByIdAndUserId(incomeId, userId);
+	}
+
 	public void setUserCategoryNull(Long userCategoryId) {
 		incomeRepository.updateUserCategoryAsNull(userCategoryId);
 	}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+import com.prgrms.tenwonmoa.domain.user.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,19 +26,20 @@ public class IncomeService {
 		return incomeRepository.save(income).getId();
 	}
 
-	public FindIncomeResponse findIncome(Long incomeId, Long userId) {
-		Income findIncome = incomeRepository.findByIdAndUserId(incomeId, userId)
-			.orElseThrow(() -> new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
+	public FindIncomeResponse findIncome(Long incomeId, User authUser) {
+		Income findIncome = findById(incomeId);
+		authUser.validateLogin(findIncome.getUser());
+
 		return FindIncomeResponse.of(findIncome);
 	}
 
-	public Income findIdAndUserId(Long incomeId, Long userId) {
-		return incomeRepository.findByIdAndUserId(incomeId, userId)
+	public Income findById(Long incomeId) {
+		return incomeRepository.findById(incomeId)
 			.orElseThrow(() -> new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
 	}
 
-	public void deleteIncome(Long incomeId, Long userId) {
-		incomeRepository.deleteByIdAndUserId(incomeId, userId);
+	public void deleteById(Long incomeId) {
+		incomeRepository.deleteById(incomeId);
 	}
 
 	public void setUserCategoryNull(Long userCategoryId) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
@@ -9,32 +9,35 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.UpdateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
 import com.prgrms.tenwonmoa.domain.user.User;
-import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class IncomeTotalService {
-	private final UserService userService;
 	private final UserCategoryService userCategoryService;
 	private final IncomeService incomeService;
 
-	@Transactional
-	public Long createIncome(Long userId, CreateIncomeRequest createIncomeRequest) {
-		User user = userService.findById(userId);
+	public Long createIncome(User authUser, CreateIncomeRequest createIncomeRequest) {
 		UserCategory userCategory = userCategoryService.findById(createIncomeRequest.getUserCategoryId());
-		Income income = createIncomeRequest.toEntity(user, userCategory, userCategory.getCategory().getName());
 
+		Income income = createIncomeRequest.toEntity(authUser, userCategory, userCategory.getCategory().getName());
 		return incomeService.save(income);
 	}
 
-	@Transactional
-	public void updateIncome(Long userId, Long incomeId, UpdateIncomeRequest updateIncomeRequest) {
-		Income income = incomeService.findIdAndUserId(incomeId, userId);
+	public void updateIncome(User authUser, Long incomeId, UpdateIncomeRequest updateIncomeRequest) {
+		Income income = incomeService.findById(incomeId);
+		authUser.validateLogin(income.getUser());
 		UserCategory userCategory = userCategoryService.findById(updateIncomeRequest.getUserCategoryId());
 
 		income.update(userCategory, updateIncomeRequest);
+	}
+
+	public void deleteIncome(Long incomeId, User authUser) {
+		Income income = incomeService.findById(incomeId);
+		authUser.validateLogin(income.getUser());
+
+		incomeService.deleteById(incomeId);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/User.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/User.java
@@ -10,6 +10,8 @@ import javax.persistence.Entity;
 import javax.persistence.Table;
 
 import com.prgrms.tenwonmoa.domain.common.BaseEntity;
+import com.prgrms.tenwonmoa.exception.UserForbiddenException;
+import com.prgrms.tenwonmoa.exception.message.Message;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,6 +38,12 @@ public class User extends BaseEntity {
 		this.email = email;
 		this.password = password;
 		this.username = username;
+	}
+
+	public void validateLogin(User findUser) {
+		if (!findUser.getId().equals(this.getId())) {
+			throw new UserForbiddenException(Message.USER_NO_AUTHENTICATION.getMessage());
+		}
 	}
 
 	private void validateUsername(String username) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/User.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/User.java
@@ -10,7 +10,7 @@ import javax.persistence.Entity;
 import javax.persistence.Table;
 
 import com.prgrms.tenwonmoa.domain.common.BaseEntity;
-import com.prgrms.tenwonmoa.exception.UserForbiddenException;
+import com.prgrms.tenwonmoa.exception.UnauthorizedUserException;
 import com.prgrms.tenwonmoa.exception.message.Message;
 
 import lombok.Getter;
@@ -41,8 +41,8 @@ public class User extends BaseEntity {
 	}
 
 	public void validateLogin(User findUser) {
-		if (!findUser.getId().equals(this.getId())) {
-			throw new UserForbiddenException(Message.USER_NO_AUTHENTICATION.getMessage());
+		if (!this.equals(findUser)) {
+			throw new UnauthorizedUserException(Message.NO_AUTHENTICATION.getMessage());
 		}
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/exception/UnauthorizedUserException.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/UnauthorizedUserException.java
@@ -1,10 +1,10 @@
 package com.prgrms.tenwonmoa.exception;
 
-public class UserForbiddenException extends RuntimeException {
+public class UnauthorizedUserException extends RuntimeException {
 
 	private final String message;
 
-	public UserForbiddenException(String message) {
+	public UnauthorizedUserException(String message) {
 		this.message = message;
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/exception/UserForbiddenException.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/UserForbiddenException.java
@@ -1,0 +1,16 @@
+package com.prgrms.tenwonmoa.exception;
+
+public class UserForbiddenException extends RuntimeException {
+
+	private final String message;
+
+	public UserForbiddenException(String message) {
+		this.message = message;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+}

--- a/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.prgrms.tenwonmoa.exception.AlreadyExistException;
+import com.prgrms.tenwonmoa.exception.UserForbiddenException;
 import com.prgrms.tenwonmoa.exception.response.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
@@ -67,6 +68,15 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(BAD_REQUEST)
+			.body(errorResponse);
+	}
+
+	@ExceptionHandler({UserForbiddenException.class})
+	public ResponseEntity<ErrorResponse> handleForbidden(Exception exception) {
+		log.error(exception.getMessage(), exception);
+		ErrorResponse errorResponse = new ErrorResponse(List.of(exception.getMessage()), BAD_REQUEST.value());
+		return ResponseEntity
+			.status(FORBIDDEN.value())
 			.body(errorResponse);
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
@@ -74,7 +74,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler({UserForbiddenException.class})
 	public ResponseEntity<ErrorResponse> handleForbidden(Exception exception) {
 		log.error(exception.getMessage(), exception);
-		ErrorResponse errorResponse = new ErrorResponse(List.of(exception.getMessage()), BAD_REQUEST.value());
+		ErrorResponse errorResponse = new ErrorResponse(List.of(exception.getMessage()), FORBIDDEN.value());
 		return ResponseEntity
 			.status(FORBIDDEN.value())
 			.body(errorResponse);

--- a/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.prgrms.tenwonmoa.exception.AlreadyExistException;
-import com.prgrms.tenwonmoa.exception.UserForbiddenException;
+import com.prgrms.tenwonmoa.exception.UnauthorizedUserException;
 import com.prgrms.tenwonmoa.exception.response.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +71,7 @@ public class GlobalExceptionHandler {
 			.body(errorResponse);
 	}
 
-	@ExceptionHandler({UserForbiddenException.class})
+	@ExceptionHandler({UnauthorizedUserException.class})
 	public ResponseEntity<ErrorResponse> handleForbidden(Exception exception) {
 		log.error(exception.getMessage(), exception);
 		ErrorResponse errorResponse = new ErrorResponse(List.of(exception.getMessage()), FORBIDDEN.value());

--- a/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 @Getter
 public enum Message {
 
+	NO_AUTHENTICATION("권한이 없습니다."),
+
 	// 사용자
 	USER_NOT_FOUND("해당 사용자는 존재하지 않습니다."),
 
@@ -40,8 +42,7 @@ public enum Message {
 	ALREADY_EXISTS_USER("이미 존재하는 유저입니다."),
 
 	// 로그인
-	INVALID_EMAIL_OR_PASSWORD("이메일 또는 비밀번호가 잘못되었습니다."),
-	USER_NO_AUTHENTICATION("다른 유저의 데이터에는 접근할 수 없습니다.");
+	INVALID_EMAIL_OR_PASSWORD("이메일 또는 비밀번호가 잘못되었습니다.");
 
 	private final String message;
 

--- a/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
@@ -40,7 +40,8 @@ public enum Message {
 	ALREADY_EXISTS_USER("이미 존재하는 유저입니다."),
 
 	// 로그인
-	INVALID_EMAIL_OR_PASSWORD("이메일 또는 비밀번호가 잘못되었습니다.");
+	INVALID_EMAIL_OR_PASSWORD("이메일 또는 비밀번호가 잘못되었습니다."),
+	USER_NO_AUTHENTICATION("다른 유저의 데이터에는 접근할 수 없습니다.");
 
 	private final String message;
 

--- a/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
@@ -12,16 +12,16 @@ import com.prgrms.tenwonmoa.domain.user.User;
 
 public class RepositoryFixture extends RepositoryTest {
 
-	public User saveUser() {
-		return save(createUser());
+	public User saveRandomUser() {
+		return save(createRandomUser());
 	}
 
-	public Category saveCategory() {
+	public Category saveIncomeCategory() {
 		return save(createIncomeCategory());
 	}
 
 	public UserCategory saveUserCategory() {
-		return save(new UserCategory(saveUser(), saveCategory()));
+		return save(new UserCategory(saveRandomUser(), saveIncomeCategory()));
 	}
 
 	public Income saveIncome() {

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -80,9 +80,9 @@ class IncomeControllerTest {
 			.willReturn(createdId);
 
 		mockMvc.perform(post(LOCATION_PREFIX)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createIncomeRequest))
+		)
 			.andExpect(status().isCreated())
 			.andExpect(content().string(String.valueOf(createdId)))
 			.andExpect(redirectedUrl(LOCATION_PREFIX + createdId))
@@ -99,9 +99,9 @@ class IncomeControllerTest {
 			.willThrow(new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
 
 		mockMvc.perform(post(LOCATION_PREFIX)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createIncomeRequest))
+		)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-create-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -114,9 +114,9 @@ class IncomeControllerTest {
 			.willReturn(findIncomeResponse);
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createIncomeRequest))
+		)
 			.andExpect(status().isOk())
 			.andDo(document("income-find-by-id", responseFields(
 				FindIncomeResponseDoc.fieldDescriptors()
@@ -129,9 +129,9 @@ class IncomeControllerTest {
 			.willThrow(new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createIncomeRequest))
+		)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-find-by-id-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -142,9 +142,9 @@ class IncomeControllerTest {
 	void 수입_수정_성공() throws Exception {
 		Long incomeId = 1L;
 		mockMvc.perform(put(LOCATION_PREFIX + "/{incomeId}", incomeId)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(updateIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(updateIncomeRequest))
+		)
 			.andExpect(status().isNoContent())
 			.andDo(document("income-update", requestFields(
 				UpdateIncomeRequestDoc.fieldDescriptors()
@@ -159,12 +159,22 @@ class IncomeControllerTest {
 
 		Long incomeId = 1L;
 		mockMvc.perform(put(LOCATION_PREFIX + "/{incomeId}", incomeId)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(updateIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(updateIncomeRequest))
+		)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-update-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
 			)));
+	}
+
+	@Test
+	void 수입_삭제_성공() throws Exception {
+		Long incomeId = 1L;
+		mockMvc.perform(delete(LOCATION_PREFIX + "/{incomeId}", incomeId)
+			.contentType(MediaType.APPLICATION_JSON)
+		)
+			.andExpect(status().isNoContent())
+			.andDo(document("income-delete"));
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -33,7 +33,7 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.UpdateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeService;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeTotalService;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
-import com.prgrms.tenwonmoa.exception.UserForbiddenException;
+import com.prgrms.tenwonmoa.exception.UnauthorizedUserException;
 
 @WebMvcTest(controllers = IncomeController.class)
 @AutoConfigureRestDocs
@@ -81,7 +81,7 @@ class IncomeControllerTest {
 	@Test
 	void 수입_권한_없음() throws Exception {
 		given(incomeService.findIncome(any(Long.class), any()))
-			.willThrow(new UserForbiddenException(USER_NO_AUTHENTICATION.getMessage()));
+			.willThrow(new UnauthorizedUserException(NO_AUTHENTICATION.getMessage()));
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
 			.contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepositoryTest.java
@@ -88,4 +88,16 @@ class IncomeRepositoryTest extends RepositoryFixture {
 			.collect(Collectors.toList());
 		assertThat(userCategories).containsExactly(null, null, null);
 	}
+
+	@Test
+	void 수입정보_삭제_성공() {
+		Income income = saveIncome();
+		Long incomeId = income.getId();
+		Long userId = income.getUser().getId();
+
+		incomeRepository.deleteByIdAndUserId(incomeId, userId);
+
+		Optional<Income> findIncome = incomeRepository.findByIdAndUserId(incomeId, userId);
+		assertThat(findIncome).isEmpty();
+	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepositoryTest.java
@@ -2,7 +2,6 @@ package com.prgrms.tenwonmoa.domain.accountbook.repository;
 
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,48 +26,11 @@ class IncomeRepositoryTest extends RepositoryFixture {
 
 	private UserCategory userCategory;
 
-	private UserCategory otherUserCategory;
-
 	@BeforeEach
 	void setup() {
 		User user = save(createUser());
-		User otherUser = save(createAnotherUser());
 		Category category = save(createIncomeCategory());
 		userCategory = save(createUserCategory(user, category));
-		otherUserCategory = save(createUserCategory(otherUser, category));
-	}
-
-	@Test
-	void 유저아이디와_수입아이디로_조회_성공() {
-		// given
-		Income income = save(createIncome(userCategory));
-		User user = income.getUser();
-
-		// when
-		Optional<Income> findIncome = incomeRepository.findByIdAndUserId(income.getId(), user.getId());
-
-		// then
-		assertThat(findIncome).isPresent();
-		Income getIncome = findIncome.get();
-		assertAll(
-			() -> assertThat(getIncome.getId()).isEqualTo(income.getId()),
-			() -> assertThat(getIncome.getUser().getId()).isEqualTo(user.getId())
-		);
-	}
-
-	@Test
-	void 로그인한아이디가_다른계정의_수입을_조회할수없다() {
-		// given
-		Income loginIncome = save(createIncome(userCategory));
-		Income otherIncome = save(createIncome(otherUserCategory));
-
-		User loginUser = loginIncome.getUser();
-
-		// when
-		Optional<Income> findIncome = incomeRepository.findByIdAndUserId(otherIncome.getId(), loginUser.getId());
-
-		// then
-		assertThat(findIncome).isEmpty();
 	}
 
 	@Test
@@ -93,11 +55,10 @@ class IncomeRepositoryTest extends RepositoryFixture {
 	void 수입정보_삭제_성공() {
 		Income income = saveIncome();
 		Long incomeId = income.getId();
-		Long userId = income.getUser().getId();
 
-		incomeRepository.deleteByIdAndUserId(incomeId, userId);
+		incomeRepository.deleteById(incomeId);
 
-		Optional<Income> findIncome = incomeRepository.findByIdAndUserId(incomeId, userId);
+		Optional<Income> findIncome = incomeRepository.findById(incomeId);
 		assertThat(findIncome).isEmpty();
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
@@ -31,6 +31,9 @@ class IncomeServiceTest {
 
 	private final Income income = createIncome(createUserCategory(createUser(), createIncomeCategory()));
 
+	private final Long incomeId = 1L;
+	private final Long userId = 1L;
+
 	@Test
 	void 수입저장_성공() {
 		given(incomeRepository.save(income)).willReturn(income);
@@ -44,9 +47,6 @@ class IncomeServiceTest {
 
 	@Test
 	void 아이디로_수입조회_성공() {
-		Long incomeId = 1L;
-		Long userId = 1L;
-
 		given(incomeRepository.findByIdAndUserId(any(Long.class), any(Long.class))).willReturn(Optional.of(income));
 
 		FindIncomeResponse findIncomeResponse = incomeService.findIncome(incomeId, userId);
@@ -68,5 +68,14 @@ class IncomeServiceTest {
 		assertThatThrownBy(() -> incomeRepository.findByIdAndUserId(1L, 1L))
 			.isInstanceOf(NoSuchElementException.class)
 			.hasMessage(Message.INCOME_NOT_FOUND.getMessage());
+	}
+
+	@Test
+	void 수입_삭제_성공() {
+		doNothing().when(incomeRepository).deleteByIdAndUserId(any(Long.class), any(Long.class));
+
+		incomeService.deleteIncome(1L, 1L);
+
+		verify(incomeRepository).deleteByIdAndUserId(incomeId, userId);
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
@@ -27,9 +27,6 @@ import com.prgrms.tenwonmoa.domain.user.service.UserService;
 @DisplayName("가계부 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
 class IncomeTotalServiceTest {
-
-	@Mock
-	private UserService userService;
 	@Mock
 	private UserCategoryService userCategoryService;
 	@Mock
@@ -40,6 +37,7 @@ class IncomeTotalServiceTest {
 	private final Income income = createIncome(createUserCategory(createUser(), createIncomeCategory()));
 	private final UserCategory userCategory = income.getUserCategory();
 	private final User user = income.getUser();
+	private final User mockUser = mock(User.class);
 
 	private final CreateIncomeRequest request = new CreateIncomeRequest(LocalDateTime.now(),
 		1000L,
@@ -53,11 +51,10 @@ class IncomeTotalServiceTest {
 
 	@Test
 	void 수입_생성_성공() {
-		given(userService.findById(any())).willReturn(user);
 		given(userCategoryService.findById(any())).willReturn(userCategory);
 		given(incomeService.save(income)).willReturn(1L);
 
-		Long savedId = incomeTotalService.createIncome(user.getId(), request);
+		Long savedId = incomeTotalService.createIncome(user, request);
 		assertAll(
 			() -> assertThat(savedId).isEqualTo(1L),
 			() -> verify(incomeService).save(income)
@@ -65,44 +62,34 @@ class IncomeTotalServiceTest {
 	}
 
 	@Test
-	void 수입_생성실패_유저정보_없는경우() {
-		given(userService.findById(any())).willThrow(new NoSuchElementException(USER_NOT_FOUND.getMessage()));
-		assertThatThrownBy(() -> incomeTotalService.createIncome(user.getId(), request))
-			.isInstanceOf(NoSuchElementException.class)
-			.hasMessage(USER_NOT_FOUND.getMessage());
-	}
-
-	@Test
 	void 수입_생성실패_유저카테고리_없는경우() {
-		given(userService.findById(any())).willReturn(user);
 		given(userCategoryService.findById(any())).willThrow(
 			new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
-		assertThatThrownBy(() -> incomeTotalService.createIncome(user.getId(), request))
+		assertThatThrownBy(() -> incomeTotalService.createIncome(user, request))
 			.isInstanceOf(NoSuchElementException.class)
 			.hasMessage(USER_CATEGORY_NOT_FOUND.getMessage());
 	}
 
 	@Test
 	void 수입_수정_성공() {
-		given(incomeService.findIdAndUserId(any(), any())).willReturn(income);
-		given(userCategoryService.findById(any())).willReturn(userCategory);
-
-		incomeTotalService.updateIncome(user.getId(),
+		given(incomeService.findById(any())).willReturn(income);
+		given(userCategoryService.findById(any(Long.class))).willReturn(userCategory);
+		incomeTotalService.updateIncome(mockUser,
 			income.getId(),
 			updateIncomeRequest
 		);
 
 		assertAll(
-			() -> verify(incomeService).findIdAndUserId(any(), any()),
+			() -> verify(incomeService).findById(any()),
 			() -> verify(userCategoryService).findById(any())
 		);
 	}
 
 	@Test
 	void 수입_수정_실패_수입정보_없는경우() {
-		given(incomeService.findIdAndUserId(any(), any())).willThrow(
+		given(incomeService.findById(any())).willThrow(
 			new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
-		assertThatThrownBy(() -> incomeTotalService.updateIncome(user.getId(),
+		assertThatThrownBy(() -> incomeTotalService.updateIncome(user,
 			income.getId(),
 			updateIncomeRequest))
 			.isInstanceOf(NoSuchElementException.class)
@@ -111,10 +98,10 @@ class IncomeTotalServiceTest {
 
 	@Test
 	void 수입_수정_실패_유저카테고리_없는경우() {
-		given(incomeService.findIdAndUserId(any(), any())).willReturn(income);
+		given(incomeService.findById(any())).willReturn(income);
 		given(userCategoryService.findById(any())).willThrow(
 			new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
-		assertThatThrownBy(() -> incomeTotalService.updateIncome(user.getId(),
+		assertThatThrownBy(() -> incomeTotalService.updateIncome(mockUser,
 			income.getId(),
 			updateIncomeRequest))
 			.isInstanceOf(NoSuchElementException.class)

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/UserTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/UserTest.java
@@ -108,5 +108,4 @@ class UserTest {
 				.hasMessageContaining(INVALID_USERNAME_PATTERN.getMessage())
 		);
 	}
-
 }


### PR DESCRIPTION
## 개요

- 수입 삭제기능 구현

## 추가기능

- delete `api/v1/incomes/{incomeId}`

## 사용방법(Optional)

- 사용자는 자신의 수입정보를 삭제할 수 있다.

## 변경사항
- @hymn-fly @jki503  두 분 리뷰때 남겼던 User를 검증하는 로직을 수입 서비스에서도 추가했습니다.
  - AS-IS: 조회 시 UserId를 조건으로 함께 찾아옴.
  - TO-BE: UserId를 조건에서 제외하여 조회한 후, 로그인 한 유저인지 유효성 검사 후 예외 처리.

### 변경이유 
- 삭제를 구현하다보니 예외처리에 대한 올바른 응답을 내려줄 수 없었습니다.
  - 자신의 수입이 아닌 데이터를 삭제요청하게 될때도 204로 응답이 처리해야했습니다. (삭제된게 없어도 예외처리하지 않고 204 반환)
  - 따라서, 유효성 검사를 통해 권한이 없는 요청인지, 없는 데이터를 조회하는것인지 구분해줄 수 있어야 한다 판단했습니다.
  - 저는 400에러보다는 403에러가 더 적합하다고 생각하여, `UserForbiddenException` 커스텀 예외를 만들어 처리해보았습니다.

## 기타

![img](https://user-images.githubusercontent.com/26343023/181923669-9bb753c2-52d5-431d-b54d-fff009852bc1.png)

![image](https://user-images.githubusercontent.com/26343023/181942608-6e5a7d09-7fd9-4a5d-870e-ffeee2c2d8c0.png)
