### PR TITLE
[#72] REST DOCS 설정 추가

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryController.java
@@ -1,0 +1,30 @@
+package com.prgrms.tenwonmoa.domain.category.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
+import com.prgrms.tenwonmoa.domain.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/categories")
+@RequiredArgsConstructor
+public class UserCategoryController {
+
+	private final UserCategoryService userCategoryService;
+
+	private final UserService userService;
+
+	@DeleteMapping("/{userCategoryId}")
+	public ResponseEntity<Void> deleteUserCategory(@PathVariable Long userCategoryId) {
+		Long userId = 1L; // 추후 AuthenticationPrincipal 적용예정
+
+		userCategoryService.deleteUserCategory(userService.findById(userId), userCategoryId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/RestDocsConfig.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/RestDocsConfig.java
@@ -1,0 +1,19 @@
+package com.prgrms.tenwonmoa.common;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfig {
+	@Bean
+	public RestDocumentationResultHandler write() {
+		return MockMvcRestDocumentation.document(
+			"{class-name}/{method-name}",
+			Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+			Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+		);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerTest.java
@@ -1,0 +1,81 @@
+package com.prgrms.tenwonmoa.domain.category.controller;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.prgrms.tenwonmoa.common.RestDocsConfig;
+import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.service.UserService;
+
+@WebMvcTest(controllers = UserCategoryController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@ExtendWith(RestDocumentationExtension.class)
+@Import(RestDocsConfig.class)
+@DisplayName("유저 카테고리 컨트롤러 테스트")
+class UserCategoryControllerTest {
+	private static final String ENDPOINT_URL_PREFIX = "/api/v1/categories/";
+
+	@Autowired
+	private RestDocumentationResultHandler restDocs;
+
+	@MockBean
+	private UserCategoryService userCategoryService;
+
+	@MockBean
+	private UserService userService;
+
+	private MockMvc mockMvc;
+
+	private final User user = createUser();
+
+	@BeforeEach
+	void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+			.apply(springSecurity())
+			.alwaysDo(restDocs)
+			.addFilters(new CharacterEncodingFilter("UTF-8", true)) // 한글 깨짐 방지
+			.build();
+	}
+
+	@Test
+	void 카테고리_삭제() throws Exception {
+		Long userCategoryId = 1L;
+
+		given(userService.findById(anyLong())).willReturn(user);
+
+		mockMvc.perform(
+				RestDocumentationRequestBuilders.delete(ENDPOINT_URL_PREFIX + "{userCategoryId}", userCategoryId))
+			.andExpect(status().isNoContent())
+			.andDo(
+				restDocs.document(
+					pathParameters(parameterWithName("userCategoryId").description("카테고리 아이디"))
+				)
+			);
+		verify(userCategoryService).deleteUserCategory(user, userCategoryId);
+	}
+}


### PR DESCRIPTION
## 개요

- 카테고리 삭제 API 구성
- REST DOCS 설정 추가


## 변경사항(Optional)
- REST DOCS 에서 document하는 부분을 mockMvc 생성 시 설정되도록 함


## 기타

- 원래는 아예 설정 부분을 따로 클래스로 빼서 진행하려 했는데 
WebMvcTest가 controllers 를 지정해서 가져오는게 아닌 그냥
@WebMvcTest 로 했을 때, unsatisfied dependency exception이 발생하더라구요 [ [관련 StackOverflow ](https://stackoverflow.com/questions/48078044/webmvctest-fails-with-java-lang-illegalstateexception-failed-to-load-applicati)] 
-- 요약 : WebMvcTest로는 해당 에러 해결못했고 SpringBootTest로 해결했다~ -- 

통합 테스트일 때는 문제가 없었는데 컨트롤러 단위 테스트로 할 때는 mockMvc 설정을 상위 클래스에서 한번에 진행하기가 어려웠습니다ㅠ

그래서 현재와 같이 적용을 하긴 했는데 이런 상태면 컨트롤러 테스트마다 이것을 작성을 해야하긴하는데,,  여러분들 의견이 궁금합니다!
