### PR TITLE
[#68] JwtAuthenticationFilter 추가

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
@@ -15,15 +15,14 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
-
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
-			.authorizeRequests()    // todo: controller 어느 정도 추가되면 antMatcher 재설정
-				.antMatchers("/**").permitAll()
-				.anyRequest().permitAll()
+			.authorizeRequests()
+				.antMatchers( "/api/v1/users", "/api/v1/users/login").permitAll()
+				.anyRequest().authenticated()
 				.and()
 			.csrf()        // disable 하지 않으면 unauthorized
 				.disable()

--- a/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
@@ -5,23 +5,37 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.web.filter.CorsFilter;
+
+import com.prgrms.tenwonmoa.domain.user.jwt.JwtAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
 			.authorizeRequests()    // todo: controller 어느 정도 추가되면 antMatcher 재설정
-			.antMatchers("/**").permitAll()
-			.anyRequest().permitAll()
-			.and()
+				.antMatchers("/**").permitAll()
+				.anyRequest().permitAll()
+				.and()
 			.csrf()        // disable 하지 않으면 unauthorized
-			.disable()
+				.disable()
 			.httpBasic()    // 토큰을 사용하므로 basic 인증 disable
-			.disable()
+				.disable()
 			.sessionManagement()    // 토큰을 사용하므로 stateless
-			.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+		// filter 등록
+		http.addFilterAfter(
+			jwtAuthenticationFilter,
+			CorsFilter.class
+		);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/Jwt.java
@@ -1,9 +1,13 @@
 package com.prgrms.tenwonmoa.domain.user.jwt;
 
+import java.util.Date;
+
 import org.springframework.stereotype.Component;
 
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.prgrms.tenwonmoa.config.JwtConfigure;
 
 import lombok.Getter;
@@ -33,6 +37,43 @@ public final class Jwt {
 		this.jwtVerifier = com.auth0.jwt.JWT.require(algorithm)
 			.withIssuer(issuer)
 			.build();
+	}
+
+	public Claims verify(String token) {
+		return new Claims(jwtVerifier.verify(token));
+	}
+
+	public static class Claims {
+
+		private Long userId;
+		private String email;
+		private Date iat;
+		private Date exp;
+
+		private Claims() {
+		}
+
+		public Claims(DecodedJWT decodedJwt) {
+			Claim userId = decodedJwt.getClaim("userId");
+			if (!userId.isNull()) {
+				this.userId = userId.asLong();
+			}
+			Claim email = decodedJwt.getClaim("email");
+			if (!email.isNull()) {
+				this.email = email.asString();
+			}
+			this.iat = decodedJwt.getIssuedAt();
+			this.exp = decodedJwt.getExpiresAt();
+		}
+
+		public Long getUserId() {
+			return userId;
+		}
+
+		public String getEmail() {
+			return email;
+		}
+
 	}
 
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/Jwt.java
@@ -39,10 +39,7 @@ public final class Jwt {
 			.build();
 	}
 
-	public Claims verify(String token) {
-		return new Claims(jwtVerifier.verify(token));
-	}
-
+	@Getter
 	public static class Claims {
 
 		private Long userId;
@@ -65,15 +62,6 @@ public final class Jwt {
 			this.iat = decodedJwt.getIssuedAt();
 			this.exp = decodedJwt.getExpiresAt();
 		}
-
-		public Long getUserId() {
-			return userId;
-		}
-
-		public String getEmail() {
-			return email;
-		}
-
 	}
 
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/JwtAuthenticationFilter.java
@@ -63,8 +63,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			} catch (Exception e) {
 				log.warn("Jwt processing 실패: {}", e.getMessage());
 			}
-		} else {
-			// todo: token 이 없으면 기능 API 호출이 불가, controller 로 가지 않도록 필터에서 처리
 		}
 
 		filterChain.doFilter(request, response);

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,77 @@
+package com.prgrms.tenwonmoa.domain.user.jwt;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.prgrms.tenwonmoa.config.JwtConfigure;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final TokenProvider tokenProvider;
+	private final JwtConfigure jwtConfigure;
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		// SecurityContext에 이미 token이 들어있음
+		if (SecurityContextHolder.getContext().getAuthentication() != null) {
+			log.debug("SecurityContextHolder에 이미 다른 security token이 들어있음: '{}'",
+				SecurityContextHolder.getContext().getAuthentication());
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		// 요청에서 토큰 가져오기
+		String token = parseToken(request);
+
+		if (StringUtils.hasText(token)) {
+			// userId 가져오기
+			Long userId = tokenProvider.validateAndGetUserId(token);
+			log.info("Authenticated user Id: {}", userId);
+
+			// 인증 완료, SecurityContextHolder 에 인증된 사용자라고 등록
+			AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+				userId,
+				null,
+				AuthorityUtils.NO_AUTHORITIES
+			);
+			authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String parseToken(HttpServletRequest request) {
+		// Http 요청의 헤더를 파싱해 Bearer 토큰 리턴
+		String bearerToken = request.getHeader(jwtConfigure.getHeader());
+		log.info("Bearer Token: {}", bearerToken);
+
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -15,8 +16,6 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import com.prgrms.tenwonmoa.config.JwtConfigure;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private static final String BEARER_PREFIX = "Bearer ";
 	private final TokenProvider tokenProvider;
-	private final JwtConfigure jwtConfigure;
 
 	@Override
 	protected void doFilterInternal(
@@ -70,7 +68,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private String parseToken(HttpServletRequest request) {
 		// Http 요청의 헤더를 파싱해 Bearer 토큰 리턴
-		String bearerToken = request.getHeader(jwtConfigure.getHeader());
+		String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
 		log.info("Bearer Token: {}", bearerToken);
 
 		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/TokenProvider.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/TokenProvider.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import org.springframework.stereotype.Component;
 
 import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.interfaces.DecodedJWT;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,12 +29,13 @@ public class TokenProvider {
 	}
 
 	public Long validateAndGetUserId(String token) {
-		Jwt.Claims claims = validate(token);
+		Jwt.Claims claims = verifyAndGetClaims(token);
 		return claims.getUserId();
 	}
 
-	private Jwt.Claims validate(String token) {
-		return jwt.verify(token);
+	private Jwt.Claims verifyAndGetClaims(String token) {
+		DecodedJWT decodedJWT = jwt.getJwtVerifier().verify(token);
+		return new Jwt.Claims(decodedJWT);
 	}
 
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/TokenProvider.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/TokenProvider.java
@@ -34,8 +34,8 @@ public class TokenProvider {
 	}
 
 	private Jwt.Claims verifyAndGetClaims(String token) {
-		DecodedJWT decodedJWT = jwt.getJwtVerifier().verify(token);
-		return new Jwt.Claims(decodedJWT);
+		DecodedJWT decodedJwt = jwt.getJwtVerifier().verify(token);
+		return new Jwt.Claims(decodedJwt);
 	}
 
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/TokenProvider.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/jwt/TokenProvider.java
@@ -27,4 +27,13 @@ public class TokenProvider {
 		return builder.sign(jwt.getAlgorithm());
 	}
 
+	public Long validateAndGetUserId(String token) {
+		Jwt.Claims claims = validate(token);
+		return claims.getUserId();
+	}
+
+	private Jwt.Claims validate(String token) {
+		return jwt.verify(token);
+	}
+
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -70,7 +70,7 @@ class IncomeControllerTest {
 	private ObjectMapper objectMapper;
 
 	@MockBean
-	private JwtAuthenticationFilter jwtAuthenticationFilter;	//
+	private JwtAuthenticationFilter jwtAuthenticationFilter;    // 테스트 실행을 위해 필요
 
 	@MockBean
 	private IncomeTotalService incomeTotalService;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -13,8 +13,8 @@ import java.util.NoSuchElementException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
@@ -26,20 +26,20 @@ import com.prgrms.tenwonmoa.common.documentdto.CreateIncomeRequestDoc;
 import com.prgrms.tenwonmoa.common.documentdto.ErrorResponseDoc;
 import com.prgrms.tenwonmoa.common.documentdto.FindIncomeResponseDoc;
 import com.prgrms.tenwonmoa.common.documentdto.UpdateIncomeRequestDoc;
-import com.prgrms.tenwonmoa.config.JwtConfigure;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.CreateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.UpdateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeService;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeTotalService;
+import com.prgrms.tenwonmoa.domain.user.jwt.JwtAuthenticationFilter;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
 import com.prgrms.tenwonmoa.exception.UnauthorizedUserException;
 
 @WebMvcTest(controllers = IncomeController.class)
+@AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
 @MockBean(JpaMetamodelMappingContext.class)
 @DisplayName("수입 컨트롤러 테스트")
-@EnableConfigurationProperties(JwtConfigure.class)
 class IncomeControllerTest {
 	private static final String LOCATION_PREFIX = "/api/v1/incomes/";
 
@@ -70,6 +70,9 @@ class IncomeControllerTest {
 	private ObjectMapper objectMapper;
 
 	@MockBean
+	private JwtAuthenticationFilter jwtAuthenticationFilter;	//
+
+	@MockBean
 	private IncomeTotalService incomeTotalService;
 
 	@MockBean
@@ -84,9 +87,9 @@ class IncomeControllerTest {
 			.willThrow(new UnauthorizedUserException(NO_AUTHENTICATION.getMessage()));
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createIncomeRequest))
+			)
 			.andExpect(status().isForbidden())
 			.andDo(document("income-forbidden", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -100,9 +103,9 @@ class IncomeControllerTest {
 			.willReturn(createdId);
 
 		mockMvc.perform(post(LOCATION_PREFIX)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createIncomeRequest))
+			)
 			.andExpect(status().isCreated())
 			.andExpect(content().string(String.valueOf(createdId)))
 			.andExpect(redirectedUrl(LOCATION_PREFIX + createdId))
@@ -119,9 +122,9 @@ class IncomeControllerTest {
 			.willThrow(new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
 
 		mockMvc.perform(post(LOCATION_PREFIX)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createIncomeRequest))
+			)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-create-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -134,9 +137,9 @@ class IncomeControllerTest {
 			.willReturn(findIncomeResponse);
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createIncomeRequest))
+			)
 			.andExpect(status().isOk())
 			.andDo(document("income-find-by-id", responseFields(
 				FindIncomeResponseDoc.fieldDescriptors()
@@ -149,9 +152,9 @@ class IncomeControllerTest {
 			.willThrow(new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createIncomeRequest))
+			)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-find-by-id-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -162,9 +165,9 @@ class IncomeControllerTest {
 	void 수입_수정_성공() throws Exception {
 		Long incomeId = 1L;
 		mockMvc.perform(put(LOCATION_PREFIX + "/{incomeId}", incomeId)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(updateIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateIncomeRequest))
+			)
 			.andExpect(status().isNoContent())
 			.andDo(document("income-update", requestFields(
 				UpdateIncomeRequestDoc.fieldDescriptors()
@@ -179,9 +182,9 @@ class IncomeControllerTest {
 
 		Long incomeId = 1L;
 		mockMvc.perform(put(LOCATION_PREFIX + "/{incomeId}", incomeId)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(updateIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateIncomeRequest))
+			)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-update-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -192,8 +195,8 @@ class IncomeControllerTest {
 	void 수입_삭제_성공() throws Exception {
 		Long incomeId = 1L;
 		mockMvc.perform(delete(LOCATION_PREFIX + "/{incomeId}", incomeId)
-			.contentType(MediaType.APPLICATION_JSON)
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+			)
 			.andExpect(status().isNoContent())
 			.andDo(document("income-delete"));
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
@@ -7,10 +7,11 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
@@ -19,15 +20,19 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.prgrms.tenwonmoa.config.JwtConfigure;
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
+import com.prgrms.tenwonmoa.domain.user.jwt.JwtAuthenticationFilter;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 @WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
 @MockBean(JpaMetamodelMappingContext.class)
-@EnableConfigurationProperties(JwtConfigure.class)
+@DisplayName("유저 컨트롤러 테스트")
 class UserControllerTest {
+
+	@MockBean
+	private JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@MockBean
 	private UserService userService;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
@@ -32,7 +32,7 @@ import com.prgrms.tenwonmoa.domain.user.service.UserService;
 class UserControllerTest {
 
 	@MockBean
-	private JwtAuthenticationFilter jwtAuthenticationFilter;
+	private JwtAuthenticationFilter jwtAuthenticationFilter;	// 테스트 실행을 위해 필요
 
 	@MockBean
 	private UserService userService;


### PR DESCRIPTION
## 개요

- JwtAuthenticationFilter 추가
- HTTP 요청에서 Jwt 토큰을 확인해 userId를 꺼내여 SecurityContext에 저장

## 추가기능

- HTTP 요청에서 Jwt 토큰을 확인해 userId를 꺼내여 SecurityContext에 저장

## 변경사항(Optional)

- IncomeControllerTest, UserControllerTest
필터 추가 후 테스트가 실행이 안되는 오류 해결
JwtAuthenticaionFilter 모킹으로 넣어줌

- TokenProvider
token을 검증해 userId를 추출하는 메소드 추가

- Jwt
Claims inner 클래스로 추가

## 사용방법(Optional)

- JwtAuthenticaionFilter
HttpServletRequest에서 jwt token 추출 -> token에서 userId 추출 -> SecurityContextHolder에 인증 사용자 추가 -> 다음 필터 수행

- Postman
로그인 api 호출 후 토큰을 받는다. -> 토큰 값을 Bearer Token에 추가 후 기능 api 호출 
![image](https://user-images.githubusercontent.com/43159295/182025214-5b6708e8-3caf-4fc3-9bd3-19b885fbaac7.png)


## 기타
- 다음과 같이 Controller 에서 `@AuthenticationPrincipal Long userId` 사용하시면 jwt로 요청을 보낸 userId를 사용할 수 있습니다.
![image](https://user-images.githubusercontent.com/43159295/182024855-8cce2b21-851f-416d-9648-b55ba774e0db.png)
![image](https://user-images.githubusercontent.com/43159295/182025059-4fe0ccbf-5806-4008-b191-d1104a79fe23.png)


