### PR TITLE
[#84] endpoint에 AuthenticationPrincipal 적용

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/ExpenditureController.java
@@ -6,6 +6,7 @@ import java.net.URISyntaxException;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,8 +34,8 @@ public class ExpenditureController {
 
 	@PostMapping
 	public ResponseEntity<CreateExpenditureResponse> createExpenditure(
-		@Valid @RequestBody CreateExpenditureRequest createExpenditureRequest) throws URISyntaxException {
-		Long userId = 1L; // 추후 Auth로 받을 예정
+		@Valid @RequestBody CreateExpenditureRequest createExpenditureRequest,
+		@AuthenticationPrincipal Long userId) throws URISyntaxException {
 		CreateExpenditureResponse response = expenditureService.createExpenditure(userId, createExpenditureRequest);
 
 		URI uri = new URI(LOCATION_PREFIX + response.getId());
@@ -44,26 +45,25 @@ public class ExpenditureController {
 	@PutMapping("/{expenditureId}")
 	public ResponseEntity<Void> updateExpenditure(
 		@PathVariable Long expenditureId,
-		@Valid @RequestBody UpdateExpenditureRequest updateExpenditureRequest
+		@Valid @RequestBody UpdateExpenditureRequest updateExpenditureRequest,
+		@AuthenticationPrincipal Long userId
 	) {
-		Long userId = 1L; // 추후 Auth로 받을 예정
 		expenditureService.updateExpenditure(userId, expenditureId, updateExpenditureRequest);
 
 		return ResponseEntity.ok().build();
 	}
 
 	@GetMapping("/{expenditureId}")
-	public ResponseEntity<FindExpenditureResponse> findExpenditure(@PathVariable Long expenditureId) {
-		Long userId = 1L; // 추후 Auth로 받을 예정
-
+	public ResponseEntity<FindExpenditureResponse> findExpenditure(
+		@PathVariable Long expenditureId, @AuthenticationPrincipal Long userId) {
 		FindExpenditureResponse response = expenditureService.findExpenditure(userId, expenditureId);
 
 		return ResponseEntity.ok(response);
 	}
 
 	@DeleteMapping("/{expenditureId}")
-	public ResponseEntity<Void> deleteExpenditure(@PathVariable Long expenditureId) {
-		Long userId = 1L; // 추후 Auth로 받을 예정
+	public ResponseEntity<Void> deleteExpenditure(
+		@PathVariable Long expenditureId, @AuthenticationPrincipal Long userId) {
 		expenditureService.deleteExpenditure(userId, expenditureId);
 
 		return ResponseEntity.noContent().build();

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,7 +20,6 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.UpdateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeService;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeTotalService;
-import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
@@ -35,36 +35,34 @@ public class IncomeController {
 	private final IncomeService incomeService;
 	private final UserService userService;
 
-	// TODO 로그인이 완성되면 AuthenticationManager를 통해가져오도록 변경한다. 그전까지 임시로 사용
-	private User authenticateUserTemp() {
-		Long userId = 1L;
-		return userService.findById(userId);
-	}
-
 	@PostMapping
-	public ResponseEntity<Long> createIncome(@RequestBody @Valid CreateIncomeRequest request) {
-		Long createdId = incomeTotalService.createIncome(authenticateUserTemp(), request);
+	public ResponseEntity<Long> createIncome(@RequestBody @Valid CreateIncomeRequest request,
+		@AuthenticationPrincipal Long userId) {
+		Long createdId = incomeTotalService.createIncome(userService.findById(userId), request);
 
 		String redirectUri = LOCATION_PREFIX + createdId;
 		return ResponseEntity.created(URI.create(redirectUri)).body(createdId);
 	}
 
 	@GetMapping("/{incomeId}")
-	public FindIncomeResponse findIncome(@PathVariable Long incomeId) {
-		return incomeService.findIncome(incomeId, authenticateUserTemp());
+	public FindIncomeResponse findIncome(@PathVariable Long incomeId,
+		@AuthenticationPrincipal Long userId) {
+		return incomeService.findIncome(incomeId, userService.findById(userId));
 	}
 
 	@PutMapping("/{incomeId}")
 	public ResponseEntity<Void> updateIncome(@PathVariable Long incomeId,
-		@RequestBody @Valid UpdateIncomeRequest updateIncomeRequest
+		@RequestBody @Valid UpdateIncomeRequest updateIncomeRequest,
+		@AuthenticationPrincipal Long userId
 	) {
-		incomeTotalService.updateIncome(authenticateUserTemp(), incomeId, updateIncomeRequest);
+		incomeTotalService.updateIncome(userService.findById(userId), incomeId, updateIncomeRequest);
 		return ResponseEntity.noContent().build();
 	}
 
 	@DeleteMapping("/{incomeId}")
-	public ResponseEntity<Void> deleteIncome(@PathVariable Long incomeId) {
-		incomeTotalService.deleteIncome(incomeId, authenticateUserTemp());
+	public ResponseEntity<Void> deleteIncome(@PathVariable Long incomeId,
+		@AuthenticationPrincipal Long userId) {
+		incomeTotalService.deleteIncome(incomeId, userService.findById(userId));
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryController.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotEmpty;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -21,6 +22,7 @@ import com.prgrms.tenwonmoa.domain.category.dto.CreateCategoryRequest;
 import com.prgrms.tenwonmoa.domain.category.dto.FindCategoryResponse;
 import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
 import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
+import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
@@ -37,37 +39,36 @@ public class UserCategoryController {
 	private final UserService userService;
 
 	@GetMapping
-	public ResponseEntity<FindCategoryResponse> findUserCategories(@RequestParam @NotEmpty String kind) {
-		Long userId = 1L;
-
+	public ResponseEntity<FindCategoryResponse> findUserCategories(
+		@RequestParam @NotEmpty String kind,
+		@AuthenticationPrincipal Long userId) {
 		return ResponseEntity.ok(findUserCategoryService.findUserCategories(userId, kind));
 	}
 
 	@PostMapping
-	public ResponseEntity<Map<String, Long>> createUserCategory(@RequestBody @Valid CreateCategoryRequest request) {
-		Long userId = 1L;
-
+	public ResponseEntity<Map<String, Long>> createUserCategory(
+		@RequestBody @Valid CreateCategoryRequest request,
+		@AuthenticationPrincipal Long userId) {
 		Long userCategoryId = userCategoryService.createUserCategory(
 			userService.findById(userId), request.getCategoryType(), request.getName());
 		return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("id", userCategoryId));
 	}
 
 	@PatchMapping("/{userCategoryId}")
-	public ResponseEntity<Map<String, String>> updateUserCategory(@PathVariable Long userCategoryId,
-		@RequestBody Map<String, Object> updateRequest) {
-
-		Long userId = 1L;
-
+	public ResponseEntity<Map<String, String>> updateUserCategory(
+		@PathVariable Long userCategoryId,
+		@RequestBody Map<String, Object> updateRequest,
+		@AuthenticationPrincipal Long userId) {
 		String updatedName = userCategoryService.updateName(userService.findById(userId), userCategoryId,
 			(String)updateRequest.get("name"));
 		return ResponseEntity.ok(Map.of("name", updatedName));
 	}
 
 	@DeleteMapping("/{userCategoryId}")
-	public ResponseEntity<Void> deleteUserCategory(@PathVariable Long userCategoryId) {
-		Long userId = 1L;
-
-		userCategoryService.deleteUserCategory(userService.findById(userId), userCategoryId);
+	public ResponseEntity<Void> deleteUserCategory(
+		@PathVariable Long userCategoryId, @AuthenticationPrincipal Long userId) {
+		User user = userService.findById(userId);
+		userCategoryService.deleteUserCategory(user, userCategoryId);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/test/java/com/prgrms/tenwonmoa/common/annotation/WithMockCustomUser.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/annotation/WithMockCustomUser.java
@@ -1,0 +1,16 @@
+package com.prgrms.tenwonmoa.common.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+	String username() default "testUser";
+
+	String password() default "12345678";
+
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/annotation/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/annotation/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,21 @@
+package com.prgrms.tenwonmoa.common.annotation;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+	@Override
+	public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+		Long principal = 1L; // userId;
+		Authentication auth = new UsernamePasswordAuthenticationToken(principal, customUser.password(),
+			AuthorityUtils.NO_AUTHORITIES);
+		context.setAuthentication(auth);
+		return context;
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
 import com.prgrms.tenwonmoa.common.documentdto.CreateIncomeRequestDoc;
 import com.prgrms.tenwonmoa.common.documentdto.ErrorResponseDoc;
 import com.prgrms.tenwonmoa.common.documentdto.FindIncomeResponseDoc;
@@ -97,6 +98,7 @@ class IncomeControllerTest {
 	}
 
 	@Test
+	@WithMockCustomUser
 	void 수입_등록_성공() throws Exception {
 		Long createdId = 1L;
 		given(incomeTotalService.createIncome(any(), any(CreateIncomeRequest.class)))
@@ -117,6 +119,7 @@ class IncomeControllerTest {
 	}
 
 	@Test
+	@WithMockCustomUser
 	void 수입_등록_실패() throws Exception {
 		given(incomeTotalService.createIncome(any(), any(CreateIncomeRequest.class)))
 			.willThrow(new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
@@ -132,6 +135,7 @@ class IncomeControllerTest {
 	}
 
 	@Test
+	@WithMockCustomUser
 	void 수입_상세조회_성공() throws Exception {
 		given(incomeService.findIncome(any(Long.class), any()))
 			.willReturn(findIncomeResponse);
@@ -147,6 +151,7 @@ class IncomeControllerTest {
 	}
 
 	@Test
+	@WithMockCustomUser
 	void 수입_상세조회_실패() throws Exception {
 		given(incomeService.findIncome(any(Long.class), any()))
 			.willThrow(new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
@@ -162,6 +167,7 @@ class IncomeControllerTest {
 	}
 
 	@Test
+	@WithMockCustomUser
 	void 수입_수정_성공() throws Exception {
 		Long incomeId = 1L;
 		mockMvc.perform(put(LOCATION_PREFIX + "/{incomeId}", incomeId)
@@ -175,6 +181,7 @@ class IncomeControllerTest {
 	}
 
 	@Test
+	@WithMockCustomUser
 	void 수입_수정_실패() throws Exception {
 		willThrow(new NoSuchElementException(INCOME_NOT_FOUND.getMessage()))
 			.given(incomeTotalService)
@@ -192,6 +199,7 @@ class IncomeControllerTest {
 	}
 
 	@Test
+	@WithMockCustomUser
 	void 수입_삭제_성공() throws Exception {
 		Long incomeId = 1L;
 		mockMvc.perform(delete(LOCATION_PREFIX + "/{incomeId}", incomeId)

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerTest.java
@@ -30,7 +30,6 @@ import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -39,6 +38,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.prgrms.tenwonmoa.common.RestDocsConfig;
+import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
 import com.prgrms.tenwonmoa.config.JwtConfigure;
 import com.prgrms.tenwonmoa.config.WebSecurityConfig;
 import com.prgrms.tenwonmoa.domain.category.dto.FindCategoryResponse;
@@ -93,7 +93,7 @@ class UserCategoryControllerTest {
 	}
 
 	@Test
-	@WithMockUser
+	@WithMockCustomUser
 	void 카테고리_조회() throws Exception {
 		String categoryType = "EXPENDITURE";
 		given(findUserCategoryService.findUserCategories(anyLong(), eq(categoryType)))
@@ -117,7 +117,7 @@ class UserCategoryControllerTest {
 	}
 
 	@Test
-	@WithMockUser
+	@WithMockCustomUser
 	void 카테고리_등록() throws Exception {
 		Long userCategoryId = 1L;
 		String categoryType = "EXPENDITURE";
@@ -148,7 +148,7 @@ class UserCategoryControllerTest {
 	}
 
 	@Test
-	@WithMockUser
+	@WithMockCustomUser
 	void 카테고리_수정() throws Exception {
 		Long userCategoryId = 1L;
 		String updateName = "수정된 분류이름";
@@ -177,7 +177,7 @@ class UserCategoryControllerTest {
 	}
 
 	@Test
-	@WithMockUser
+	@WithMockCustomUser
 	void 카테고리_삭제() throws Exception {
 		Long userCategoryId = 1L;
 


### PR DESCRIPTION
## 개요

- JwtAuthenticationFilter 활용하여 AuthenticationPrincipal 값 가지고 오는 기능 적용함
- 테스트에서 AuthenticationPrincipal을 만들어서 넣어주기 위한 CusotmAnnotation 생성 [[참고 문서](https://docs.spring.io/spring-security/site/docs/5.2.0.RELEASE/reference/html/test.html)]

## 추가기능
- jwt token Bearer 로 담아서 보내면 AuthenticationPrincipal에서 userId 가져옴
- 해당 userId를 테스트 시에도 가져올 수 있도록 어노테이션 적용함

## 사용방법(Optional)

- @WithMockCustomUser 를 테스트 메서드에 붙이면 SecurityContext에서 principal에 1L을 갖는 UsernamePasswordAuthenticationToken  만들어서 넣어줌
- 알아서 컨트롤러에서 @AuthenticationPrincipal로 값 가져옴
