### PR TITLE
[#99] 토큰 response body, Cookie로 반환

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
@@ -10,6 +10,7 @@ public class ServletConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/api/**")
+			.allowCredentials(true)
 			.allowedOrigins("http://localhost:3000", "https://team-10jo-10wonmoa-fe.vercel.app")
 			.allowedMethods("*")
 			.allowedHeaders("*");


### PR DESCRIPTION
## 개요

- 프론트 팀 요청으로 기존에 header에 token 값을 보내주는 것을 cookie, response body로 응답하는걸로 변경

## 변경사항(Optional)

- UserController
header의 token 값만 넘겨줬음 -> response body, cookie(access-token, token-value) 형태로 응답하도록 변경

## 기타
로그인 성공 시 다음처럼 응답하도록 변경
<img width="971" alt="image" src="https://user-images.githubusercontent.com/43159295/182301751-8039a7db-8d3c-4b4b-b454-98cd13a23a4d.png">
<img width="927" alt="image" src="https://user-images.githubusercontent.com/43159295/182301802-7f85c3f9-7a9e-41e7-a1cd-8422025d26b2.png">



