### PR TITLE
[#105] 수입컨트롤러에서 userService제거

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
@@ -20,7 +20,6 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.income.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.UpdateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeService;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeTotalService;
-import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,12 +32,11 @@ public class IncomeController {
 
 	private final IncomeTotalService incomeTotalService;
 	private final IncomeService incomeService;
-	private final UserService userService;
 
 	@PostMapping
 	public ResponseEntity<Long> createIncome(@RequestBody @Valid CreateIncomeRequest request,
 		@AuthenticationPrincipal Long userId) {
-		Long createdId = incomeTotalService.createIncome(userService.findById(userId), request);
+		Long createdId = incomeTotalService.createIncome(userId, request);
 
 		String redirectUri = LOCATION_PREFIX + createdId;
 		return ResponseEntity.created(URI.create(redirectUri)).body(createdId);
@@ -47,7 +45,7 @@ public class IncomeController {
 	@GetMapping("/{incomeId}")
 	public FindIncomeResponse findIncome(@PathVariable Long incomeId,
 		@AuthenticationPrincipal Long userId) {
-		return incomeService.findIncome(incomeId, userService.findById(userId));
+		return incomeService.findIncome(incomeId, userId);
 	}
 
 	@PutMapping("/{incomeId}")
@@ -55,14 +53,14 @@ public class IncomeController {
 		@RequestBody @Valid UpdateIncomeRequest updateIncomeRequest,
 		@AuthenticationPrincipal Long userId
 	) {
-		incomeTotalService.updateIncome(userService.findById(userId), incomeId, updateIncomeRequest);
+		incomeTotalService.updateIncome(userId, incomeId, updateIncomeRequest);
 		return ResponseEntity.noContent().build();
 	}
 
 	@DeleteMapping("/{incomeId}")
 	public ResponseEntity<Void> deleteIncome(@PathVariable Long incomeId,
 		@AuthenticationPrincipal Long userId) {
-		incomeTotalService.deleteIncome(incomeId, userService.findById(userId));
+		incomeTotalService.deleteIncome(incomeId, userId);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
-import com.prgrms.tenwonmoa.domain.user.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,10 +25,10 @@ public class IncomeService {
 		return incomeRepository.save(income).getId();
 	}
 
-	public FindIncomeResponse findIncome(Long incomeId, User authUser) {
+	public FindIncomeResponse findIncome(Long incomeId, Long authId) {
 		Income findIncome = findById(incomeId);
-		authUser.validateLogin(findIncome.getUser());
 
+		findIncome.getUser().validateLogin(authId);
 		return FindIncomeResponse.of(findIncome);
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
@@ -9,6 +9,7 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.income.UpdateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
 import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,26 +19,27 @@ import lombok.RequiredArgsConstructor;
 public class IncomeTotalService {
 	private final UserCategoryService userCategoryService;
 	private final IncomeService incomeService;
+	private final UserService userService;
 
-	public Long createIncome(User authUser, CreateIncomeRequest createIncomeRequest) {
+	public Long createIncome(Long userId, CreateIncomeRequest createIncomeRequest) {
 		UserCategory userCategory = userCategoryService.findById(createIncomeRequest.getUserCategoryId());
 
+		User authUser = userService.findById(userId);
 		Income income = createIncomeRequest.toEntity(authUser, userCategory, userCategory.getCategory().getName());
 		return incomeService.save(income);
 	}
 
-	public void updateIncome(User authUser, Long incomeId, UpdateIncomeRequest updateIncomeRequest) {
+	public void updateIncome(Long authId, Long incomeId, UpdateIncomeRequest updateIncomeRequest) {
 		Income income = incomeService.findById(incomeId);
-		authUser.validateLogin(income.getUser());
+		income.getUser().validateLogin(authId);
 		UserCategory userCategory = userCategoryService.findById(updateIncomeRequest.getUserCategoryId());
-
 		income.update(userCategory, updateIncomeRequest);
 	}
 
-	public void deleteIncome(Long incomeId, User authUser) {
+	public void deleteIncome(Long incomeId, Long authId) {
 		Income income = incomeService.findById(incomeId);
-		authUser.validateLogin(income.getUser());
-
+		income.getUser().validateLogin(authId);
 		incomeService.deleteById(incomeId);
 	}
+
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/User.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/User.java
@@ -40,8 +40,8 @@ public class User extends BaseEntity {
 		this.username = username;
 	}
 
-	public void validateLogin(User findUser) {
-		if (!this.equals(findUser)) {
+	public void validateLogin(Long authId) {
+		if (!this.getId().equals(authId)) {
 			throw new UnauthorizedUserException(Message.NO_AUTHENTICATION.getMessage());
 		}
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
-import com.prgrms.tenwonmoa.domain.accountbook.dto.income.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
 import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.exception.message.Message;
@@ -32,7 +31,8 @@ class IncomeServiceTest {
 
 	private final Income income = createIncome(createUserCategory(createUser(), createIncomeCategory()));
 
-	private final Long incomeId = 1L;
+	private User mockUser = mock(User.class);
+	private Income mockIncome = mock(Income.class);
 
 	@Test
 	void 수입저장_성공() {
@@ -47,19 +47,12 @@ class IncomeServiceTest {
 
 	@Test
 	void 아이디로_수입조회_성공() {
-		User mockUser = mock(User.class);
-		doNothing().when(mockUser).validateLogin(income.getUser());
-		given(incomeRepository.findById(any(Long.class))).willReturn(Optional.of(income));
+		given(incomeRepository.findById(anyLong())).willReturn(Optional.of(mockIncome));
+		given(mockIncome.getUser()).willReturn(mockUser);
+		doNothing().when(mockUser).validateLogin(anyLong());
 
-		FindIncomeResponse findIncomeResponse = incomeService.findIncome(incomeId, mockUser);
-		assertAll(
-			() -> assertThat(findIncomeResponse.getId()).isEqualTo(income.getId()),
-			() -> assertThat(findIncomeResponse.getRegisterDate()).isEqualTo(income.getRegisterDate()),
-			() -> assertThat(findIncomeResponse.getAmount()).isEqualTo(income.getAmount()),
-			() -> assertThat(findIncomeResponse.getContent()).isEqualTo(income.getContent()),
-			() -> assertThat(findIncomeResponse.getCategoryName()).isEqualTo(income.getCategoryName()),
-			() -> verify(incomeRepository).findById(incomeId)
-		);
+		incomeService.findIncome(mockIncome.getId(), anyLong());
+		verify(incomeRepository).findById(anyLong());
 	}
 
 	@Test


### PR DESCRIPTION
## 개요

- 수입컨트롤러에서 userService제거

## 변경 전
- Authentication에서 userId로 UserEntity를 찾아서 반환 함.

## 변경 후
- Controller에서는 id만 전달.
- Service에서 Entity가 필요한 경우에만 객체를 찾아서 처리.
  - 구지 모든 서비스에서 Entity를 찾아올 필요가 없을것 같다.

