### PR TITLE
[#69] 시큐리티 파일들 user.security 패키지로 이동

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
@@ -10,7 +10,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.filter.CorsFilter;
 
-import com.prgrms.tenwonmoa.domain.user.jwt.JwtAuthenticationFilter;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.JwtAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/Jwt.java
@@ -1,4 +1,4 @@
-package com.prgrms.tenwonmoa.domain.user.jwt;
+package com.prgrms.tenwonmoa.domain.user.security.jwt;
 
 import java.util.Date;
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.prgrms.tenwonmoa.domain.user.jwt;
+package com.prgrms.tenwonmoa.domain.user.security.jwt;
 
 import java.io.IOException;
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/TokenProvider.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/TokenProvider.java
@@ -1,4 +1,4 @@
-package com.prgrms.tenwonmoa.domain.user.jwt;
+package com.prgrms.tenwonmoa.domain.user.security.jwt;
 
 import java.util.Date;
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
@@ -10,8 +10,8 @@ import com.prgrms.tenwonmoa.domain.category.service.CreateDefaultUserCategorySer
 import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
 import com.prgrms.tenwonmoa.domain.user.dto.LoginUserResponse;
-import com.prgrms.tenwonmoa.domain.user.security.jwt.TokenProvider;
 import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.TokenProvider;
 import com.prgrms.tenwonmoa.exception.AlreadyExistException;
 import com.prgrms.tenwonmoa.exception.message.Message;
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
@@ -10,7 +10,7 @@ import com.prgrms.tenwonmoa.domain.category.service.CreateDefaultUserCategorySer
 import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
 import com.prgrms.tenwonmoa.domain.user.dto.LoginUserResponse;
-import com.prgrms.tenwonmoa.domain.user.jwt.TokenProvider;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.TokenProvider;
 import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
 import com.prgrms.tenwonmoa.exception.AlreadyExistException;
 import com.prgrms.tenwonmoa.exception.message.Message;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -32,7 +32,7 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.income.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.UpdateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeService;
 import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeTotalService;
-import com.prgrms.tenwonmoa.domain.user.jwt.JwtAuthenticationFilter;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.JwtAuthenticationFilter;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
 import com.prgrms.tenwonmoa.exception.UnauthorizedUserException;
 

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerTest.java
@@ -46,7 +46,7 @@ import com.prgrms.tenwonmoa.domain.category.dto.FindCategoryResponse.SingleCateg
 import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
 import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
 import com.prgrms.tenwonmoa.domain.user.User;
-import com.prgrms.tenwonmoa.domain.user.jwt.JwtAuthenticationFilter;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.JwtAuthenticationFilter;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 @WebMvcTest(controllers = UserCategoryController.class,

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
-import com.prgrms.tenwonmoa.domain.user.jwt.JwtAuthenticationFilter;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.JwtAuthenticationFilter;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 @WebMvcTest(UserController.class)

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/jwt/TokenProviderTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/jwt/TokenProviderTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.prgrms.tenwonmoa.config.JwtConfigure;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.Jwt;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.TokenProvider;
 
 @DisplayName("토큰 생성기 테스트")
 @ExtendWith(SpringExtension.class)

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserServiceTest.java
@@ -20,7 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.prgrms.tenwonmoa.domain.category.service.CreateDefaultUserCategoryService;
 import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
-import com.prgrms.tenwonmoa.domain.user.jwt.TokenProvider;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.TokenProvider;
 import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
 import com.prgrms.tenwonmoa.exception.AlreadyExistException;
 import com.prgrms.tenwonmoa.exception.message.Message;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserServiceTest.java
@@ -20,8 +20,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.prgrms.tenwonmoa.domain.category.service.CreateDefaultUserCategoryService;
 import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
-import com.prgrms.tenwonmoa.domain.user.security.jwt.TokenProvider;
 import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.TokenProvider;
 import com.prgrms.tenwonmoa.exception.AlreadyExistException;
 import com.prgrms.tenwonmoa.exception.message.Message;
 


### PR DESCRIPTION
## 개요

- 시큐리티 관련 파일들 user.security 패키지 안으로 이동
- 기존에는 시큐리티 관련 파일들을 user 패키지에서 관리했음
- refreshToken 파일과, 추후 oauth 관련 파일들을 관리하기 위해 user.security 패키지로 이동하기로 생각함

## 변경사항(Optional)

- user.jwt -> user.security.jwt 패키지 이동

