### PR TITLE
[#97] 카테고리 삭제 시, userCategory 삭제안하고 category만 삭제되도록 수정

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
@@ -37,7 +37,7 @@ public class Expenditure extends BaseEntity {
 	@Column(name = "amount", nullable = false)
 	private Long amount;
 
-	@Column(name = "content", nullable = true, length = CONTENT_MAX)
+	@Column(name = "content", length = CONTENT_MAX)
 	private String content;
 
 	@Column(name = "category_name", nullable = false, length = Category.MAX_NAME_LENGTH)
@@ -92,17 +92,10 @@ public class Expenditure extends BaseEntity {
 	 * TODO : naming 부자연스럽지 않은지 조언 필요
 	 * */
 	public String getCategoryName() {
-		if (Objects.isNull(this.userCategory)) {
+		if (Objects.isNull(this.userCategory.getCategory())) {
 			return this.categoryName;
 		}
 
-		return this.userCategory.getCategory().getName();
-	}
-
-	/**
-	 * TODO : 의논 필요, 윌리엄이 userCategory 만들때 null 설정할 메서드
-	 * */
-	public void deleteUserCategory() {
-		this.userCategory = null;
+		return this.userCategory.getCategoryName();
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Income.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Income.java
@@ -104,15 +104,11 @@ public class Income extends BaseEntity {
 	}
 
 	public String getCategoryName() {
-		if (Objects.isNull(this.userCategory)) {
+		if (Objects.isNull(this.userCategory.getCategory())) {
 			return this.categoryName;
 		}
 
-		return this.userCategory.getCategory().getName();
-	}
-
-	public void deleteUserCategory() {
-		this.userCategory = null;
+		return this.userCategory.getCategoryName();
 	}
 
 	private void validateAmount(Long amount) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/UserCategory.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/UserCategory.java
@@ -26,7 +26,7 @@ public class UserCategory extends BaseEntity {
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	@ManyToOne(fetch = EAGER, optional = false)
+	@ManyToOne(fetch = EAGER)
 	@JoinColumn(name = "category_id")
 	private Category category;
 
@@ -44,5 +44,9 @@ public class UserCategory extends BaseEntity {
 
 	public CategoryType getCategoryType() {
 		return this.category.getCategoryType();
+	}
+
+	public void updateCategoryAsNull() {
+		this.category = null;
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepository.java
@@ -11,9 +11,10 @@ import com.prgrms.tenwonmoa.domain.category.UserCategory;
 
 @Repository
 public interface UserCategoryRepository extends JpaRepository<UserCategory, Long> {
+
 	@Query("select uc from UserCategory uc "
 		+ "join fetch uc.category c "
-		+ "where uc.user.id = :userId and c.categoryType = :categoryType")
+		+ "where uc.user.id = :userId "
+		+ "and c.categoryType = :categoryType")
 	List<UserCategory> findByUserIdAndCategoryType(Long userId, CategoryType categoryType);
-
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryService.java
@@ -38,6 +38,10 @@ public class UserCategoryService {
 		validateUser(authenticatedUser, user);
 
 		Category category = userCategory.getCategory();
+
+		checkNotNull(category, String.format(
+			"삭제된 카테고리는 수정할 수 없습니다, 유저 아이디 : %d, 유저 카테고리 아이디 : %d 업데이트할 이름 : %s",
+			authenticatedUser.getId(), userCategoryId, desiredName));
 		category.updateName(desiredName);
 
 		return category.getName();

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryService.java
@@ -7,8 +7,6 @@ import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.prgrms.tenwonmoa.domain.accountbook.service.ExpenditureService;
-import com.prgrms.tenwonmoa.domain.accountbook.service.IncomeService;
 import com.prgrms.tenwonmoa.domain.category.Category;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
@@ -25,10 +23,6 @@ public class UserCategoryService {
 	private final UserCategoryRepository userCategoryRepository;
 
 	private final CategoryService categoryService;
-
-	private final ExpenditureService expenditureService;
-
-	private final IncomeService incomeService;
 
 	public Long createUserCategory(User user, String catgoryType, String name) {
 		Category savedCategory = categoryService.createCategory(catgoryType, name);
@@ -61,16 +55,12 @@ public class UserCategoryService {
 	}
 
 	public void deleteUserCategory(User authenticatedUser, Long userCategoryId) {
-		incomeService.setUserCategoryNull(userCategoryId);
-		expenditureService.setUserCategoryNull(userCategoryId);
-
 		UserCategory userCategory = findById(userCategoryId);
 		User user = userCategory.getUser();
 		validateUser(authenticatedUser, user);
 
-		userCategoryRepository.delete(userCategory);
-
 		Category category = userCategory.getCategory();
+		userCategory.updateCategoryAsNull();
 		categoryService.deleteCategory(category.getId());
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryService.java
@@ -65,6 +65,10 @@ public class UserCategoryService {
 
 		Category category = userCategory.getCategory();
 		userCategory.updateCategoryAsNull();
+
+		checkNotNull(category, String.format(
+			"삭제된 카테고리는 다시 삭제할 수 없습니다, 유저 아이디 : %d, 유저 카테고리 아이디 : %d",
+			authenticatedUser.getId(), userCategoryId));
 		categoryService.deleteCategory(category.getId());
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler {
 	}
 
 	// 공격 or 버그
-	@ExceptionHandler({NoSuchElementException.class})
+	@ExceptionHandler({NoSuchElementException.class, NullPointerException.class})
 	public ResponseEntity<ErrorResponse> handleBug(RuntimeException exception) {
 		log.error(exception.getMessage(), exception);
 		ErrorResponse errorResponse = new ErrorResponse(List.of(exception.getMessage()), BAD_REQUEST.value());

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/ExpenditureTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/ExpenditureTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.tenwonmoa.domain.accountbook;
 
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
@@ -198,6 +199,8 @@ class ExpenditureTest {
 	@DisplayName("지출의 userCategory를 지우거나, category 이름을 제대로 불러오는지")
 	class DeleteExpenditureAndGetCategoryName {
 
+		private final UserCategory userCategory = createUserCategory(user, category);
+
 		private final Expenditure expenditure = new Expenditure(
 			date,
 			amount,
@@ -208,21 +211,14 @@ class ExpenditureTest {
 		);
 
 		@Test
-		public void 유저카테고리를_지운다() {
-			expenditure.deleteUserCategory();
-
-			assertThat(expenditure.getUserCategory()).isNull();
-		}
-
-		@Test
-		public void 유저카테고리를_지웠을때_카테고리이름을_불러온다() {
-			expenditure.deleteUserCategory();
+		public void 카테고리를_지웠을때_카테고리이름을_불러온다() {
+			userCategory.updateCategoryAsNull();
 
 			assertThat(expenditure.getCategoryName()).isEqualTo(categoryName);
 		}
 
 		@Test
-		public void 유저카테고리를_지우지_않았을때_저장된_카테고리의_이름을_불러온다() {
+		public void 카테고리를_지우지_않았을때_저장된_카테고리의_이름을_불러온다() {
 			assertThat(expenditure.getCategoryName()).isEqualTo(category.getName());
 		}
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/IncomeTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/IncomeTest.java
@@ -147,28 +147,15 @@ class IncomeTest {
 	}
 
 	@Test
-	public void 유저카테고리를_지운다() {
-		//given
-		Income income = new Income(
-			LocalDateTime.now(), 1000L, null, category.getName(), user, userCategory);
-
-		//when
-		income.deleteUserCategory();
-
-		//then
-		assertThat(income.getUserCategory()).isNull();
-	}
-
-	@Test
-	public void 유저카테고리를_지웠을때_필드에_있는_카테고리이름을_불러온다() {
+	public void 카테고리를_지웠을때_필드에_있는_카테고리이름을_불러온다() {
 		//given
 		String categoryName = "커스텀카테고리이름";
-		String userCategoryName = userCategory.getCategory().getName();
+		String userCategoryName = userCategory.getCategoryName();
 		Income income = new Income(
 			LocalDateTime.now(), 1000L, null, categoryName, user, userCategory);
 
 		//when
-		income.deleteUserCategory();
+		userCategory.updateCategoryAsNull();
 
 		//then
 		String resultCategoryName = income.getCategoryName();
@@ -178,7 +165,7 @@ class IncomeTest {
 	}
 
 	@Test
-	public void 유저카테고리를_지우지_않았을때_유저카테고리의_카테고리의_이름을_불러온다() {
+	public void 카테고리를_지우지_않았을때_유저카테고리의_카테고리의_이름을_불러온다() {
 		//given
 		String categoryName = "다른카테고리";
 		String userCategoryName = userCategory.getCategory().getName();

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/UserCategoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/UserCategoryTest.java
@@ -58,4 +58,16 @@ class UserCategoryTest {
 		//then
 		assertThat(userCategory.getCategoryType()).isEqualTo(CategoryType.EXPENDITURE);
 	}
+
+	@Test
+	void 카테고리_삭제_성공() {
+		//given
+		Category category = new Category("식비", CategoryType.EXPENDITURE);
+		UserCategory userCategory = new UserCategory(user, category);
+
+		//when
+		userCategory.updateCategoryAsNull();
+		//then
+		assertThat(userCategory.getCategory()).isNull();
+	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepositoryTest.java
@@ -44,12 +44,18 @@ class UserCategoryRepositoryTest extends RepositoryTest {
 
 		userCategoryRepository.save(createUserCategory(user, expenditureCategory));
 
+		UserCategory userCategory = userCategoryRepository.save(createUserCategory(user, expenditureCategory));
+		userCategory.updateCategoryAsNull();
+		save(userCategory);
+
 		// when
-		List<UserCategory> userCategories =
+		List<UserCategory> allUserCategories = userCategoryRepository.findAll();
+		List<UserCategory> expenditureCategories =
 			userCategoryRepository.findByUserIdAndCategoryType(user.getId(), CategoryType.EXPENDITURE);
 
 		// then
-		assertThat(userCategories).hasSize(1);
-		assertThat(userCategories.get(0).getCategoryType()).isEqualTo(CategoryType.EXPENDITURE);
+		assertThat(allUserCategories).hasSize(3);
+		assertThat(expenditureCategories).hasSize(1);
+		assertThat(expenditureCategories.get(0).getCategoryType()).isEqualTo(CategoryType.EXPENDITURE);
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
@@ -149,6 +149,23 @@ class UserCategoryServiceTest {
 		assertThatIllegalStateException().isThrownBy(
 			() -> userCategoryService.updateName(otherUser, userCategoryId, "업데이트된 카테고리 이름")
 		);
+
+	}
+
+	@Test
+	void 삭제된_카테고리는_카테고리_이름_수정_실패() {
+		//given
+		String categoryType = "EXPENDITURE";
+		String categoryName = "예시지출카테고리";
+		Long userCategoryId = userCategoryService.createUserCategory(user, categoryType, categoryName);
+		userCategoryService.deleteUserCategory(user, userCategoryId);
+
+		//when
+		//then
+		assertThatNullPointerException().isThrownBy(
+			() -> userCategoryService.updateName(user, userCategoryId, "업데이트된 카테고리 이름")
+		);
+
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
@@ -206,7 +206,7 @@ class UserCategoryServiceTest {
 		//when
 		userCategoryService.deleteUserCategory(user, userCategoryId);
 		//then
-		assertThatExceptionOfType(NullPointerException.class)
+		assertThatNullPointerException()
 			.isThrownBy(() -> userCategoryService.deleteUserCategory(user, userCategoryId));
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/service/UserCategoryServiceTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -163,8 +162,8 @@ class UserCategoryServiceTest {
 		userCategoryService.deleteUserCategory(user, userCategoryId);
 
 		//then
-		assertThatExceptionOfType(NoSuchElementException.class)
-			.isThrownBy(() -> userCategoryService.findById(userCategoryId));
+		UserCategory userCategory = userCategoryService.findById(userCategoryId);
+		assertThat(userCategory.getCategory()).isNull();
 	}
 
 	@Test
@@ -181,42 +180,16 @@ class UserCategoryServiceTest {
 	}
 
 	@Test
-	void 유저카테고리를_갖고있는_지출과_수입이_있어도_유저카테고리_삭제_성공() {
+	void 이미_삭제가_된_유저카테고리는_삭제_실패() {
 		//given
 		String categoryType = "EXPENDITURE";
 		String categoryName = "예시지출카테고리";
 		Long userCategoryId = userCategoryService.createUserCategory(user, categoryType, categoryName);
-		UserCategory userCategory = userCategoryService.findById(userCategoryId);
-
-		Expenditure savedExpenditure = expenditureRepository.save(
-			new Expenditure(LocalDateTime.now(), 10000L, "내용", "식비", user, userCategory));
-		Income savedIncome = incomeRepository.save(
-			new Income(LocalDateTime.now(), 10000L, "내용", "식비", user, userCategory));
-		new Expenditure(LocalDateTime.now(), 10000L, "내용", "식비", user, userCategory);
 
 		//when
 		userCategoryService.deleteUserCategory(user, userCategoryId);
-
 		//then
-		assertThatExceptionOfType(NoSuchElementException.class)
-			.isThrownBy(() -> userCategoryService.findById(userCategoryId));
-
-		Optional<Expenditure> expenditureOptional = expenditureRepository.findById(savedExpenditure.getId());
-		Optional<Income> incomeOptional = incomeRepository.findById(savedIncome.getId());
-
-		assertThat(expenditureOptional).isPresent();
-		assertThat(expenditureOptional.get().getUserCategory()).isNull();
-
-		assertThat(incomeOptional).isPresent();
-		assertThat(incomeOptional.get().getUserCategory()).isNull();
-
-	}
-
-	@Test
-	void 유저카테고리_존재하지_않을시_삭제_실패() {
-		//when
-		//then
-		assertThatExceptionOfType(NoSuchElementException.class)
-			.isThrownBy(() -> userCategoryService.deleteUserCategory(user, 1L));
+		assertThatExceptionOfType(NullPointerException.class)
+			.isThrownBy(() -> userCategoryService.deleteUserCategory(user, userCategoryId));
 	}
 }


### PR DESCRIPTION
## 개요
- 유저카테고리가 삭제되었을 때, 지출과 수입에서 해당 id를 계속 가지고 있도록 하기 위하여(통계를 위해)
유저 카테고리는 삭제 하지 않고 카테고리만 삭제함

## 추가기능
- UserCategory 에서 category를 null로 업데이트 하는 함수

## 변경사항(Optional)
수입, 지출 도메인
- 수입, 지출에서 deleteUserCategory 로직 삭제
- getCategoryName() 메서드 호출 시, category가 null일 때 name을 반환하도록 수정

UserCategory 도메인
- UserCategory에서 category가 null 일 수 있기에 optional=true를 제거함
- UserCategory 도메인 로직 updateCategoryAsNull 추가

UserCategoryService
- 유저 카테고리 삭제 로직 중, Expenditure, Income의 UserCategory 를 null 처리 x
- UserCategory의 category 값만 null로 변경
