### PR TITLE
[#112] swagger 연동 의존성 및 config 추가

### DIFF
--- a/.github/workflows/tenwonmoa-ci.yml
+++ b/.github/workflows/tenwonmoa-ci.yml
@@ -49,6 +49,7 @@ jobs:
           cp appspec.yml before-deploy/
           cp scripts/*.sh before-deploy/
           cp build/libs/*.jar before-deploy/
+          cp docker-compose-dev.yml before-deploy/
           cd before-deploy && zip -r before-deploy *
           cd ../ && mkdir -p deploy
           mv before-deploy/before-deploy.zip deploy/$DEPLOY_ZIP_FILE

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'checkstyle'
     id 'jacoco'
     id "org.asciidoctor.jvm.convert" version "3.3.2"
+    id 'com.epages.restdocs-api-spec' version '0.16.0'
 }
 
 ext {
@@ -82,11 +83,12 @@ dependencies {
     implementation 'com.auth0:java-jwt:3.18.1'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.0'
 }
 
 test {
     useJUnitPlatform()
-    finalizedBy 'jacocoTestReport'
+    finalizedBy 'jacocoTestReport', 'openapi3'
     outputs.dir snippetsDir
 }
 
@@ -196,8 +198,20 @@ task copySecret(type: Copy) {
 
 processResources.dependsOn('copySecret')
 
-build {
-    dependsOn copyDocument
+openapi3 {
+    server = 'http://3.39.184.232:8080'
+    title = 'Tenwonmoa API'
+    description = 'Tenwonmoa API description'
+    version = '1.0.0'
+    format = 'yaml'
 }
 
+task copyOpenApi(type: Copy) {
+    from file("build/api-spec")
+    into file("src/main/resources/static/docs")
+}
 
+build {
+    dependsOn copyDocument
+    finalizedBy 'copyOpenApi'
+}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,9 @@
+version: "3.7"
+services:
+  tenwonmoa-swagger:
+    image: swaggerapi/swagger-ui
+    container_name: tenwonmoa-swagger
+    ports:
+      - 8082:8080
+    environment:
+      API_URL: http://3.39.184.232:8080/docs/openapi3.yaml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,7 +33,7 @@ echo "> Docker 재실행"
 sudo service docker restart
 
 echo "> SwaggerUI 컨테이너 실행"
-sudo docker-compose -f docker-compose-dev.yml up -d
+sudo docker-compose -f $REPOSITORY/zip/docker-compose-dev.yml up -d
 
 echo "> $JAR_NAME 실행"
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,9 +29,13 @@ echo "> $JAR_NAME 실행권한 추가"
 
 sudo chmod +x $JAR_NAME
 
-echo "> $JAR_NAME 실행"
+echo "> Docker 재실행"
+sudo service docker restart
 
-## docker 실행해야 함.
+echo "> SwaggerUI 컨테이너 실행"
+sudo docker-compose -f docker-compose-dev.yml up -d
+
+echo "> $JAR_NAME 실행"
 
 nohup java -jar -Dspring.profiles.active=dev $JAR_NAME --server.port=8080 \
 $JAR_NAME > $REPOSITORY/nohup.out 2>&1 &

--- a/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
@@ -7,11 +7,19 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class ServletConfig implements WebMvcConfigurer {
 
+	public static final String SWAGGER_UI_HOST = "http://3.39.184.232:8082";
+
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/api/**")
 			.allowCredentials(true)
 			.allowedOrigins("http://localhost:3000", "https://team-10jo-10wonmoa-fe.vercel.app")
+			.allowedMethods("*")
+			.allowedHeaders("*");
+
+		registry.addMapping("/docs/**")
+			.allowCredentials(true)
+			.allowedOrigins(SWAGGER_UI_HOST)
 			.allowedMethods("*")
 			.allowedHeaders("*");
 	}

--- a/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
@@ -13,7 +13,7 @@ public class ServletConfig implements WebMvcConfigurer {
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/api/**")
 			.allowCredentials(true)
-			.allowedOrigins("http://localhost:3000", "https://team-10jo-10wonmoa-fe.vercel.app")
+			.allowedOrigins("http://localhost:3000", "https://team-10jo-10wonmoa-fe.vercel.app", SWAGGER_UI_HOST)
 			.allowedMethods("*")
 			.allowedHeaders("*");
 

--- a/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
@@ -18,6 +18,9 @@ public class ServletConfig implements WebMvcConfigurer {
 			.allowedHeaders("*");
 
 		registry.addMapping("/**")
-			.allowedOrigins(SWAGGER_UI_HOST);
+			.allowCredentials(true)
+			.allowedOrigins(SWAGGER_UI_HOST)
+			.allowedMethods("*")
+			.allowedHeaders("*");
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/ServletConfig.java
@@ -17,10 +17,7 @@ public class ServletConfig implements WebMvcConfigurer {
 			.allowedMethods("*")
 			.allowedHeaders("*");
 
-		registry.addMapping("/docs/**")
-			.allowCredentials(true)
-			.allowedOrigins(SWAGGER_UI_HOST)
-			.allowedMethods("*")
-			.allowedHeaders("*");
+		registry.addMapping("/**")
+			.allowedOrigins(SWAGGER_UI_HOST);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
@@ -31,7 +31,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 			.cors()
 			.and()
 			.authorizeRequests()
-			.antMatchers("/api/v1/users", "/api/v1/users/login").permitAll()
+			.antMatchers("/api/v1/users", "/api/v1/users/login", "/docs/**").permitAll()
 			.anyRequest().authenticated()
 			.and()
 			.csrf()        // disable 하지 않으면 unauthorized

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -16,13 +16,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-create:
-                value: "{\"registerDate\":\"2022-08-03T00:49:00.716411\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:20:34.041198\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-create-fail:
-                value: "{\"registerDate\":\"2022-08-03T00:49:00.749698\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:20:34.077937\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "201":
@@ -39,7 +39,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-create-fail:
                   value: "{\"messages\":[\"해당 사용자 카테고리는 존재하지 않습니다.\"],\"status\":400}"
@@ -61,14 +61,8 @@ paths:
             schema:
               $ref: '#/components/schemas/api-v1-incomes-486549215'
             examples:
-              income-find-by-id-fail:
-                value: "{\"registerDate\":\"2022-08-03T00:49:00.788601\",\"amount\"\
-                  :1000,\"content\":\"content\",\"userCategoryId\":1}"
-              income-find-by-id:
-                value: "{\"registerDate\":\"2022-08-03T00:49:00.767635\",\"amount\"\
-                  :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-forbidden:
-                value: "{\"registerDate\":\"2022-08-03T00:49:00.804763\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:20:34.14094\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "400":
@@ -76,7 +70,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-find-by-id-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -88,7 +82,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-incomes-incomeId-1128985720'
               examples:
                 income-find-by-id:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-03T00:49:00.767646\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-03T13:20:34.100659\"\
                     ,\"amount\":1000,\"content\":\"content\",\"categoryName\":\"용돈\
                     \"}"
         "403":
@@ -96,7 +90,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-forbidden:
                   value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
@@ -115,13 +109,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-update:
-                value: "{\"registerDate\":\"2022-08-03T00:48:59.615524\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:20:33.000045\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
               income-update-fail:
-                value: "{\"registerDate\":\"2022-08-03T00:49:00.674563\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:20:34.004125\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
       responses:
         "204":
@@ -131,7 +125,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-update-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -151,7 +145,7 @@ paths:
           description: "204"
 components:
   schemas:
-    api-v1-incomes-incomeId-940438351:
+    api-v1-incomes--940438351:
       type: object
       properties:
         messages:
@@ -166,7 +160,7 @@ components:
         status:
           type: number
           description: 에러 코드
-    api-v1-incomes-incomeId1988379506:
+    api-v1-incomes-1988379506:
       type: object
       properties:
         amount:

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -1,0 +1,203 @@
+openapi: 3.0.1
+info:
+  title: Tenwonmoa API
+  description: Tenwonmoa API description
+  version: 1.0.0
+servers:
+- url: http://3.39.184.232:8080
+tags: []
+paths:
+  /api/v1/incomes/:
+    post:
+      tags:
+      - api
+      operationId: income-create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
+            examples:
+              income-create:
+                value: "{\"registerDate\":\"2022-08-03T00:49:00.716411\",\"amount\"\
+                  :1000,\"content\":\"content\",\"userCategoryId\":1}"
+              income-create-fail:
+                value: "{\"registerDate\":\"2022-08-03T00:49:00.749698\",\"amount\"\
+                  :1000,\"content\":\"content\",\"userCategoryId\":1}"
+      responses:
+        "201":
+          description: "201"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-incomes-486549215'
+              examples:
+                income-create:
+                  value: "1"
+        "400":
+          description: "400"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+              examples:
+                income-create-fail:
+                  value: "{\"messages\":[\"해당 사용자 카테고리는 존재하지 않습니다.\"],\"status\":400}"
+  /api/v1/incomes/{incomeId}:
+    get:
+      tags:
+      - api
+      operationId: income-f
+      parameters:
+      - name: incomeId
+        in: path
+        description: ""
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api-v1-incomes-486549215'
+            examples:
+              income-find-by-id-fail:
+                value: "{\"registerDate\":\"2022-08-03T00:49:00.788601\",\"amount\"\
+                  :1000,\"content\":\"content\",\"userCategoryId\":1}"
+              income-find-by-id:
+                value: "{\"registerDate\":\"2022-08-03T00:49:00.767635\",\"amount\"\
+                  :1000,\"content\":\"content\",\"userCategoryId\":1}"
+              income-forbidden:
+                value: "{\"registerDate\":\"2022-08-03T00:49:00.804763\",\"amount\"\
+                  :1000,\"content\":\"content\",\"userCategoryId\":1}"
+      responses:
+        "400":
+          description: "400"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+              examples:
+                income-find-by-id-fail:
+                  value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-1128985720'
+              examples:
+                income-find-by-id:
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-03T00:49:00.767646\"\
+                    ,\"amount\":1000,\"content\":\"content\",\"categoryName\":\"용돈\
+                    \"}"
+        "403":
+          description: "403"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+              examples:
+                income-forbidden:
+                  value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
+    put:
+      tags:
+      - api
+      operationId: income-update
+      parameters:
+      - name: incomeId
+        in: path
+        description: ""
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
+            examples:
+              income-update:
+                value: "{\"registerDate\":\"2022-08-03T00:48:59.615524\",\"amount\"\
+                  :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
+              income-update-fail:
+                value: "{\"registerDate\":\"2022-08-03T00:49:00.674563\",\"amount\"\
+                  :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
+      responses:
+        "204":
+          description: "204"
+        "400":
+          description: "400"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+              examples:
+                income-update-fail:
+                  value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
+    delete:
+      tags:
+      - api
+      operationId: income-delete
+      parameters:
+      - name: incomeId
+        in: path
+        description: ""
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: "204"
+components:
+  schemas:
+    api-v1-incomes-incomeId-940438351:
+      type: object
+      properties:
+        messages:
+          type: array
+          description: 예외 메시지
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        status:
+          type: number
+          description: 에러 코드
+    api-v1-incomes-incomeId1988379506:
+      type: object
+      properties:
+        amount:
+          type: number
+          description: 수입 금액
+        userCategoryId:
+          type: number
+          description: 유저 카테고리 ID
+        content:
+          type: string
+          description: 내용
+        registerDate:
+          type: string
+          description: 수입 등록 날짜
+    api-v1-incomes-incomeId-1128985720:
+      type: object
+      properties:
+        amount:
+          type: number
+          description: 수입 금액
+        id:
+          type: number
+          description: 수입 ID
+        categoryName:
+          type: string
+          description: 카테고리 이름
+        content:
+          type: string
+          description: 내용
+        registerDate:
+          type: string
+          description: 수입 등록 날짜
+    api-v1-incomes-486549215:
+      type: object

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -16,13 +16,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-create:
-                value: "{\"registerDate\":\"2022-08-03T13:24:30.677172\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:38:52.931873\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-create-fail:
-                value: "{\"registerDate\":\"2022-08-03T13:24:30.716606\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:38:52.983633\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "201":
@@ -30,7 +30,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId486549215'
+                $ref: '#/components/schemas/api-v1-incomes-486549215'
               examples:
                 income-create:
                   value: "1"
@@ -39,7 +39,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-create-fail:
                   value: "{\"messages\":[\"해당 사용자 카테고리는 존재하지 않습니다.\"],\"status\":400}"
@@ -55,22 +55,13 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/api-v1-incomes-incomeId486549215'
-            examples:
-              income-forbidden:
-                value: "{\"registerDate\":\"2022-08-03T13:24:30.811887\",\"amount\"\
-                  :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "400":
           description: "400"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-find-by-id-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -82,7 +73,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-incomes-incomeId-1128985720'
               examples:
                 income-find-by-id:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-03T13:24:30.74081\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-03T13:38:53.008104\"\
                     ,\"amount\":1000,\"content\":\"content\",\"categoryName\":\"용돈\
                     \"}"
         "403":
@@ -90,7 +81,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-forbidden:
                   value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
@@ -109,13 +100,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-update:
-                value: "{\"registerDate\":\"2022-08-03T13:24:29.546947\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:38:51.688782\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
               income-update-fail:
-                value: "{\"registerDate\":\"2022-08-03T13:24:30.639147\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:38:52.88538\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
       responses:
         "204":
@@ -125,7 +116,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-update-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -145,7 +136,7 @@ paths:
           description: "204"
 components:
   schemas:
-    api-v1-incomes-incomeId-940438351:
+    api-v1-incomes--940438351:
       type: object
       properties:
         messages:
@@ -160,7 +151,7 @@ components:
         status:
           type: number
           description: 에러 코드
-    api-v1-incomes-incomeId1988379506:
+    api-v1-incomes-1988379506:
       type: object
       properties:
         amount:
@@ -193,5 +184,5 @@ components:
         registerDate:
           type: string
           description: 수입 등록 날짜
-    api-v1-incomes-incomeId486549215:
+    api-v1-incomes-486549215:
       type: object

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -16,13 +16,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
             examples:
               income-create:
-                value: "{\"registerDate\":\"2022-08-03T13:20:34.041198\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:24:30.677172\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-create-fail:
-                value: "{\"registerDate\":\"2022-08-03T13:20:34.077937\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:24:30.716606\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "201":
@@ -30,7 +30,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-486549215'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId486549215'
               examples:
                 income-create:
                   value: "1"
@@ -39,7 +39,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes--940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-create-fail:
                   value: "{\"messages\":[\"해당 사용자 카테고리는 존재하지 않습니다.\"],\"status\":400}"
@@ -59,10 +59,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-486549215'
+              $ref: '#/components/schemas/api-v1-incomes-incomeId486549215'
             examples:
               income-forbidden:
-                value: "{\"registerDate\":\"2022-08-03T13:20:34.14094\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:24:30.811887\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "400":
@@ -70,7 +70,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes--940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-find-by-id-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -82,7 +82,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-incomes-incomeId-1128985720'
               examples:
                 income-find-by-id:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-03T13:20:34.100659\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-03T13:24:30.74081\"\
                     ,\"amount\":1000,\"content\":\"content\",\"categoryName\":\"용돈\
                     \"}"
         "403":
@@ -90,7 +90,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes--940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-forbidden:
                   value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
@@ -109,13 +109,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
             examples:
               income-update:
-                value: "{\"registerDate\":\"2022-08-03T13:20:33.000045\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:24:29.546947\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
               income-update-fail:
-                value: "{\"registerDate\":\"2022-08-03T13:20:34.004125\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T13:24:30.639147\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
       responses:
         "204":
@@ -125,7 +125,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes--940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-update-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -145,7 +145,7 @@ paths:
           description: "204"
 components:
   schemas:
-    api-v1-incomes--940438351:
+    api-v1-incomes-incomeId-940438351:
       type: object
       properties:
         messages:
@@ -160,7 +160,7 @@ components:
         status:
           type: number
           description: 에러 코드
-    api-v1-incomes-1988379506:
+    api-v1-incomes-incomeId1988379506:
       type: object
       properties:
         amount:
@@ -193,5 +193,5 @@ components:
         registerDate:
           type: string
           description: 수입 등록 날짜
-    api-v1-incomes-486549215:
+    api-v1-incomes-incomeId486549215:
       type: object

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -1,10 +1,10 @@
 package com.prgrms.tenwonmoa.domain.accountbook.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.prgrms.tenwonmoa.exception.message.Message.*;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
@@ -88,9 +88,9 @@ class IncomeControllerTest {
 			.willThrow(new UnauthorizedUserException(NO_AUTHENTICATION.getMessage()));
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createIncomeRequest))
+		)
 			.andExpect(status().isForbidden())
 			.andDo(document("income-forbidden", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -105,9 +105,9 @@ class IncomeControllerTest {
 			.willReturn(createdId);
 
 		mockMvc.perform(post(LOCATION_PREFIX)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createIncomeRequest))
+		)
 			.andExpect(status().isCreated())
 			.andExpect(content().string(String.valueOf(createdId)))
 			.andExpect(redirectedUrl(LOCATION_PREFIX + createdId))
@@ -125,9 +125,9 @@ class IncomeControllerTest {
 			.willThrow(new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
 
 		mockMvc.perform(post(LOCATION_PREFIX)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createIncomeRequest))
+		)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-create-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -141,9 +141,9 @@ class IncomeControllerTest {
 			.willReturn(findIncomeResponse);
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createIncomeRequest))
+		)
 			.andExpect(status().isOk())
 			.andDo(document("income-find-by-id", responseFields(
 				FindIncomeResponseDoc.fieldDescriptors()
@@ -157,9 +157,9 @@ class IncomeControllerTest {
 			.willThrow(new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createIncomeRequest))
+		)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-find-by-id-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -171,9 +171,9 @@ class IncomeControllerTest {
 	void 수입_수정_성공() throws Exception {
 		Long incomeId = 1L;
 		mockMvc.perform(put(LOCATION_PREFIX + "/{incomeId}", incomeId)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(updateIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(updateIncomeRequest))
+		)
 			.andExpect(status().isNoContent())
 			.andDo(document("income-update", requestFields(
 				UpdateIncomeRequestDoc.fieldDescriptors()
@@ -189,9 +189,9 @@ class IncomeControllerTest {
 
 		Long incomeId = 1L;
 		mockMvc.perform(put(LOCATION_PREFIX + "/{incomeId}", incomeId)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(updateIncomeRequest))
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(updateIncomeRequest))
+		)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-update-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -203,8 +203,8 @@ class IncomeControllerTest {
 	void 수입_삭제_성공() throws Exception {
 		Long incomeId = 1L;
 		mockMvc.perform(delete(LOCATION_PREFIX + "/{incomeId}", incomeId)
-				.contentType(MediaType.APPLICATION_JSON)
-			)
+			.contentType(MediaType.APPLICATION_JSON)
+		)
 			.andExpect(status().isNoContent())
 			.andDo(document("income-delete"));
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -87,10 +87,7 @@ class IncomeControllerTest {
 		given(incomeService.findIncome(any(Long.class), any()))
 			.willThrow(new UnauthorizedUserException(NO_AUTHENTICATION.getMessage()));
 
-		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
-		)
+		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId()))
 			.andExpect(status().isForbidden())
 			.andDo(document("income-forbidden", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -140,9 +137,7 @@ class IncomeControllerTest {
 		given(incomeService.findIncome(any(Long.class), any()))
 			.willReturn(findIncomeResponse);
 
-		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-			.contentType(MediaType.APPLICATION_JSON)
-		)
+		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId()))
 			.andExpect(status().isOk())
 			.andDo(document("income-find-by-id", responseFields(
 				FindIncomeResponseDoc.fieldDescriptors()
@@ -155,9 +150,7 @@ class IncomeControllerTest {
 		given(incomeService.findIncome(any(Long.class), any()))
 			.willThrow(new NoSuchElementException(INCOME_NOT_FOUND.getMessage()));
 
-		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
-			.contentType(MediaType.APPLICATION_JSON)
-		)
+		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId()))
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-find-by-id-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -142,7 +142,6 @@ class IncomeControllerTest {
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
 			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
 		)
 			.andExpect(status().isOk())
 			.andDo(document("income-find-by-id", responseFields(
@@ -158,7 +157,6 @@ class IncomeControllerTest {
 
 		mockMvc.perform(get(LOCATION_PREFIX + "/{incomeId}", findIncomeResponse.getId())
 			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
 		)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-find-by-id-fail", responseFields(


### PR DESCRIPTION
## 개요
- swagger 연동 의존성 및 config 추가

## 설명
- openapi3 추가 -> test의존성을 읽어 yaml 형식의 swagger문서를 만든다.
- 문서에 접근할 수 있는 권한을 허용한다. (security설정 추가)
- import를 변경하여 swagger 문서화를 가능하게 한다. 

## 사용방법

1. 기존 restdocs를 사용했을 때 사용하던 아래 2개의 import를 변경해준다. 
``` java
// import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
// import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
```

2. build를 수행한다.

3. `/resources/static/docs/openapi3.yaml` 에 문서화가 반영됐는지 확인한다.

4. 변경된 `openapi3.yaml` 파일을 함께 push한다.

## 기타
- 해당 [pr](https://github.com/prgrms-web-devcourse/Team-10jo-10wonmoa-BE/pull/111)이 merge된 이후에 main 과 현재 브랜치를 병합한 후, 최종 merge 진행할 예정입니다.


