### PR TITLE
[#110] 수입 상세조회, 업데이트, 생성 변경

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Income.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Income.java
@@ -73,6 +73,10 @@ public class Income extends BaseEntity {
 		changeContent(updateIncomeRequest.getContent());
 	}
 
+	public void validateOwner(Long authId) {
+		this.user.validateLogin(authId);
+	}
+
 	private void changeContent(String content) {
 		validateContent(content);
 		this.content = content;

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeController.java
@@ -1,6 +1,7 @@
 package com.prgrms.tenwonmoa.domain.accountbook.controller;
 
 import java.net.URI;
+import java.util.Map;
 
 import javax.validation.Valid;
 
@@ -34,12 +35,12 @@ public class IncomeController {
 	private final IncomeService incomeService;
 
 	@PostMapping
-	public ResponseEntity<Long> createIncome(@RequestBody @Valid CreateIncomeRequest request,
+	public ResponseEntity<Map<String, Long>> createIncome(@RequestBody @Valid CreateIncomeRequest request,
 		@AuthenticationPrincipal Long userId) {
 		Long createdId = incomeTotalService.createIncome(userId, request);
 
 		String redirectUri = LOCATION_PREFIX + createdId;
-		return ResponseEntity.created(URI.create(redirectUri)).body(createdId);
+		return ResponseEntity.created(URI.create(redirectUri)).body(Map.of("id", createdId));
 	}
 
 	@GetMapping("/{incomeId}")

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/income/FindIncomeResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/income/FindIncomeResponse.java
@@ -17,14 +17,17 @@ public class FindIncomeResponse {
 
 	private final String content;
 
+	private final Long userCategoryId;
+
 	private final String categoryName;
 
 	public FindIncomeResponse(Long id, LocalDateTime registerDate, Long amount, String content,
-		String categoryName) {
+		Long userCategoryId, String categoryName) {
 		this.id = id;
 		this.registerDate = registerDate;
 		this.amount = amount;
 		this.content = content;
+		this.userCategoryId = userCategoryId;
 		this.categoryName = categoryName;
 	}
 
@@ -34,6 +37,7 @@ public class FindIncomeResponse {
 			income.getRegisterDate(),
 			income.getAmount(),
 			income.getContent(),
+			income.getUserCategory().getId(),
 			income.getCategoryName()
 		);
 	}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/income/UpdateIncomeRequest.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/income/UpdateIncomeRequest.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
@@ -35,8 +36,19 @@ public class UpdateIncomeRequest {
 		this.userCategoryId = userCategoryId;
 	}
 
-	public Income toEntity(User user, UserCategory userCategory, String categoryName) {
+	public Income toIncome(User user, UserCategory userCategory, String categoryName) {
 		return new Income(
+			this.registerDate,
+			this.amount,
+			this.content,
+			categoryName,
+			user,
+			userCategory
+		);
+	}
+
+	public Expenditure toExpenditure(User user, UserCategory userCategory, String categoryName) {
+		return new Expenditure(
 			this.registerDate,
 			this.amount,
 			this.content,

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeService.java
@@ -28,7 +28,7 @@ public class IncomeService {
 	public FindIncomeResponse findIncome(Long incomeId, Long authId) {
 		Income findIncome = findById(incomeId);
 
-		findIncome.getUser().validateLogin(authId);
+		findIncome.validateOwner(authId);
 		return FindIncomeResponse.of(findIncome);
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
@@ -38,9 +38,8 @@ public class IncomeTotalService {
 		UserCategory userCategory = userCategoryService.findById(updateIncomeRequest.getUserCategoryId());
 		if (CategoryType.isExpenditure(userCategory.getCategory().getCategoryType())) {
 			incomeService.deleteById(incomeId);
-			User authUser = userService.findById(authId);
 			expenditureRepository.save(
-				updateIncomeRequest.toExpenditure(authUser, userCategory, userCategory.getCategoryName()));
+				updateIncomeRequest.toExpenditure(income.getUser(), userCategory, userCategory.getCategoryName()));
 		} else {
 			income.update(userCategory, updateIncomeRequest);
 		}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
@@ -34,7 +34,7 @@ public class IncomeTotalService {
 
 	public void updateIncome(Long authId, Long incomeId, UpdateIncomeRequest updateIncomeRequest) {
 		Income income = incomeService.findById(incomeId);
-		income.getUser().validateLogin(authId);
+		income.validateOwner(authId);
 		UserCategory userCategory = userCategoryService.findById(updateIncomeRequest.getUserCategoryId());
 		if (CategoryType.isExpenditure(userCategory.getCategory().getCategoryType())) {
 			incomeService.deleteById(incomeId);
@@ -47,7 +47,7 @@ public class IncomeTotalService {
 
 	public void deleteIncome(Long incomeId, Long authId) {
 		Income income = incomeService.findById(incomeId);
-		income.getUser().validateLogin(authId);
+		income.validateOwner(authId);
 		incomeService.deleteById(incomeId);
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/CategoryType.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/CategoryType.java
@@ -2,4 +2,8 @@ package com.prgrms.tenwonmoa.domain.category;
 
 public enum CategoryType {
 	INCOME, EXPENDITURE;
+
+	public static boolean isExpenditure(CategoryType type) {
+		return type == EXPENDITURE;
+	}
 }

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -16,13 +16,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
             examples:
               income-create:
-                value: "{\"registerDate\":\"2022-08-03T13:38:52.931873\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T15:39:24.381136\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-create-fail:
-                value: "{\"registerDate\":\"2022-08-03T13:38:52.983633\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T15:39:24.446201\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "201":
@@ -30,16 +30,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-486549215'
+                $ref: '#/components/schemas/api-v1-incomes--373420824'
               examples:
                 income-create:
-                  value: "1"
+                  value: "{\"id\":1}"
         "400":
           description: "400"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes--940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-create-fail:
                   value: "{\"messages\":[\"해당 사용자 카테고리는 존재하지 않습니다.\"],\"status\":400}"
@@ -61,7 +61,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes--940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-find-by-id-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -70,18 +70,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-1128985720'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-1674408626'
               examples:
                 income-find-by-id:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-03T13:38:53.008104\"\
-                    ,\"amount\":1000,\"content\":\"content\",\"categoryName\":\"용돈\
-                    \"}"
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-03T15:39:24.48051\"\
+                    ,\"amount\":1000,\"content\":\"content\",\"userCategoryId\":1,\"\
+                    categoryName\":\"용돈\"}"
         "403":
           description: "403"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes--940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-forbidden:
                   value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
@@ -100,13 +100,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
             examples:
               income-update:
-                value: "{\"registerDate\":\"2022-08-03T13:38:51.688782\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T15:39:23.00676\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
               income-update-fail:
-                value: "{\"registerDate\":\"2022-08-03T13:38:52.88538\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-03T15:39:24.289697\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
       responses:
         "204":
@@ -116,7 +116,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes--940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-update-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -136,7 +136,7 @@ paths:
           description: "204"
 components:
   schemas:
-    api-v1-incomes--940438351:
+    api-v1-incomes-incomeId-940438351:
       type: object
       properties:
         messages:
@@ -151,7 +151,7 @@ components:
         status:
           type: number
           description: 에러 코드
-    api-v1-incomes-1988379506:
+    api-v1-incomes-incomeId1988379506:
       type: object
       properties:
         amount:
@@ -166,12 +166,21 @@ components:
         registerDate:
           type: string
           description: 수입 등록 날짜
-    api-v1-incomes-incomeId-1128985720:
+    api-v1-incomes--373420824:
+      type: object
+      properties:
+        id:
+          type: number
+          description: 생성된 수입 아이디
+    api-v1-incomes-incomeId-1674408626:
       type: object
       properties:
         amount:
           type: number
           description: 수입 금액
+        userCategoryId:
+          type: number
+          description: 유저 카테고리 ID
         id:
           type: number
           description: 수입 ID
@@ -184,5 +193,3 @@ components:
         registerDate:
           type: string
           description: 수입 등록 날짜
-    api-v1-incomes-486549215:
-      type: object

--- a/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindIncomeResponseDoc.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindIncomeResponseDoc.java
@@ -18,6 +18,7 @@ public enum FindIncomeResponseDoc {
 	REGISTER_DATE(STRING, "registerDate", "수입 등록 날짜"),
 	AMOUNT(NUMBER, "amount", "수입 금액"),
 	CONTENT(STRING, "content", "내용"),
+	USER_CATEGORY_ID(NUMBER, "userCategoryId", "유저 카테고리 ID"),
 	CATEGORY_NAME(STRING, "categoryName", "카테고리 이름");
 
 	private final JsonFieldType type;
@@ -36,6 +37,7 @@ public enum FindIncomeResponseDoc {
 			REGISTER_DATE.getFieldDescriptor(),
 			AMOUNT.getFieldDescriptor(),
 			CONTENT.getFieldDescriptor(),
+			USER_CATEGORY_ID.getFieldDescriptor(),
 			CATEGORY_NAME.getFieldDescriptor()
 		);
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,7 +57,7 @@ class IncomeControllerTest {
 		LocalDateTime.now(),
 		1000L,
 		"content",
-		"용돈"
+		1L, "용돈"
 	);
 
 	private final UpdateIncomeRequest updateIncomeRequest = new UpdateIncomeRequest(LocalDateTime.now(),
@@ -106,11 +107,13 @@ class IncomeControllerTest {
 			.content(objectMapper.writeValueAsString(createIncomeRequest))
 		)
 			.andExpect(status().isCreated())
-			.andExpect(content().string(String.valueOf(createdId)))
 			.andExpect(redirectedUrl(LOCATION_PREFIX + createdId))
 			.andDo(document("income-create",
 				requestFields(
 					CreateIncomeRequestDoc.fieldDescriptors()
+				),
+				responseFields(
+					fieldWithPath("id").type(JsonFieldType.NUMBER).description("생성된 수입 아이디")
 				)
 			));
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.exception.message.Message;
 
@@ -33,6 +34,7 @@ class IncomeServiceTest {
 
 	private User mockUser = mock(User.class);
 	private Income mockIncome = mock(Income.class);
+	private UserCategory mockUserCategory = mock(UserCategory.class);
 
 	@Test
 	void 수입저장_성공() {
@@ -49,6 +51,7 @@ class IncomeServiceTest {
 	void 아이디로_수입조회_성공() {
 		given(incomeRepository.findById(anyLong())).willReturn(Optional.of(mockIncome));
 		given(mockIncome.getUser()).willReturn(mockUser);
+		given(mockIncome.getUserCategory()).willReturn(mockUserCategory);
 		doNothing().when(mockUser).validateLogin(anyLong());
 
 		incomeService.findIncome(mockIncome.getId(), anyLong());

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
@@ -106,7 +106,6 @@ class IncomeTotalServiceTest {
 		doNothing().when(mockUser).validateLogin(anyLong());
 		UserCategory expenditureCategory = createUserCategory(income.getUser(), createExpenditureCategory());
 		given(userCategoryService.findById(anyLong())).willReturn(expenditureCategory);
-		given(userService.findById(anyLong())).willReturn(income.getUser());
 
 		// when
 		incomeTotalService.updateIncome(anyLong(),

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
@@ -16,15 +16,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.CreateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.UpdateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
 import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
-@DisplayName("가계부 서비스 테스트")
+@DisplayName("수입 통합 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
 class IncomeTotalServiceTest {
 	@Mock
@@ -33,6 +35,8 @@ class IncomeTotalServiceTest {
 	private IncomeService incomeService;
 	@Mock
 	private UserService userService;
+	@Mock
+	private ExpenditureRepository expenditureRepository;
 	@InjectMocks
 	private IncomeTotalService incomeTotalService;
 
@@ -88,8 +92,33 @@ class IncomeTotalServiceTest {
 		);
 
 		assertAll(
+			() -> verify(incomeService, never()).deleteById(any()),
+			() -> verify(expenditureRepository, never()).save(any(Expenditure.class)),
 			() -> verify(incomeService).findById(any()),
 			() -> verify(userCategoryService).findById(any())
+		);
+	}
+
+	@Test
+	void 수입_수정_지출로_변경되는경우_성공() {
+		given(incomeService.findById(any())).willReturn(mockIncome);
+		given(mockIncome.getUser()).willReturn(mockUser);
+		doNothing().when(mockUser).validateLogin(anyLong());
+		UserCategory expenditureCategory = createUserCategory(income.getUser(), createExpenditureCategory());
+		given(userCategoryService.findById(anyLong())).willReturn(expenditureCategory);
+		given(userService.findById(anyLong())).willReturn(income.getUser());
+
+		// when
+		incomeTotalService.updateIncome(anyLong(),
+			income.getId(),
+			updateIncomeRequest
+		);
+
+		// then
+		assertAll(
+			() -> verify(incomeService).deleteById(any()),
+			() -> verify(expenditureRepository).save(any(Expenditure.class)),
+			() -> verify(mockIncome, never()).update(any(UserCategory.class), any(UpdateIncomeRequest.class))
 		);
 	}
 


### PR DESCRIPTION
## 변경 전
- 수입 변경
  - 수입 -> 지출 변경 고려하지 않음

- 수입 상세 Response에 userCategoryId 포함되지 않음

- 수입, 지출의 Response가 통일되지 않음

## 변경 후

- 수입 -> 지출 변경 고려하지 않음
  - 유저가 선택된 UserCategoryId가 지출일 경우 수입을 삭제하고(delete) -> 지출을 insert 한다.

- 수입 상세 Response에 userCategoryId 포함되지 않음
  - 수입 상세 -> 수정 로직이므로, userCategoryId를 포함시키도록 변경
  - 현재 기존 update 로직 에서는 userCategoryId를 받고 있음.

- 수입, 지출의 Response가 통일되지 않음
  - 수입 생성 응답 `{"id":1} 형식`으로 변경