### PR TITLE
[#103] 일별 상세내역 쿼리 리팩터

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
@@ -5,6 +5,7 @@ import static com.prgrms.tenwonmoa.domain.accountbook.AccountBookConst.*;
 import static javax.persistence.FetchType.*;
 import static lombok.AccessLevel.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -104,5 +105,9 @@ public class Expenditure extends BaseEntity {
 	 * */
 	public void deleteUserCategory() {
 		this.userCategory = null;
+	}
+
+	public LocalDate getDate() {
+		return this.registerDate.toLocalDate();
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Income.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Income.java
@@ -7,6 +7,7 @@ import static javax.persistence.FetchType.*;
 import static lombok.AccessLevel.*;
 import static org.springframework.util.StringUtils.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -123,5 +124,9 @@ public class Income extends BaseEntity {
 	private void validateCategoryName(String categoryName) {
 		checkArgument(hasText(categoryName));
 		checkArgument(categoryName.length() <= Category.MAX_NAME_LENGTH);
+	}
+
+	public LocalDate getDate() {
+		return this.registerDate.toLocalDate();
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/DayDetail.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/DayDetail.java
@@ -35,10 +35,11 @@ public class DayDetail implements Comparable<DayDetail> {
 	 * 2.type이 같으면 등록한 최신 순으로
 	 * */
 	@Override
-	public int compareTo(DayDetail d) {
-		if (this.type.equals(d.type))
-			return this.registerTime.isAfter(d.registerTime) ? -1 : 1;
+	public int compareTo(DayDetail dayDetail) {
+		if (this.type.equals(dayDetail.type)) {
+			return this.registerTime.isAfter(dayDetail.registerTime) ? -1 : 1;
+		}
 
-		return this.type.compareTo(d.getType());
+		return this.type.compareTo(dayDetail.getType());
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/DayDetail.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/DayDetail.java
@@ -1,11 +1,11 @@
 package com.prgrms.tenwonmoa.domain.accountbook.dto;
 
-import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
 
 import lombok.Getter;
 
 @Getter
-public class DayDetail {
+public class DayDetail implements Comparable<DayDetail> {
 
 	private final Long id;
 
@@ -17,12 +17,28 @@ public class DayDetail {
 
 	private final String categoryName;
 
-	@QueryProjection
-	public DayDetail(Long id, String type, Long amount, String content, String categoryName) {
+	private final LocalDateTime registerTime;
+
+	public DayDetail(Long id, String type, Long amount, String content, String categoryName,
+		LocalDateTime registerTime) {
 		this.id = id;
 		this.type = type;
 		this.amount = amount;
 		this.content = content;
 		this.categoryName = categoryName;
+		this.registerTime = registerTime;
+	}
+
+	/**
+	 * 날짜별 상세 정렬 기준
+	 * 1.type: INCOME, EXPENDITURE 순으로 정렬
+	 * 2.type이 같으면 등록한 최신 순으로
+	 * */
+	@Override
+	public int compareTo(DayDetail d) {
+		if (this.type.equals(d.type))
+			return this.registerTime.isAfter(d.registerTime) ? -1 : 1;
+
+		return this.type.compareTo(d.getType());
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindDayAccountResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindDayAccountResponse.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 
 @Getter
-public class FindDayAccountResponse {
+public class FindDayAccountResponse implements Comparable<FindDayAccountResponse> {
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private final LocalDate registerDate;
@@ -28,5 +28,13 @@ public class FindDayAccountResponse {
 		this.dayIncome = dayIncome;
 		this.dayExpenditure = dayExpenditure;
 		this.dayDetails = dayDetails;
+	}
+
+	/**
+	 * 날짜 최신순으로 정렬
+	 * */
+	@Override
+	public int compareTo(FindDayAccountResponse r) {
+		return this.registerDate.isAfter(r.getRegisterDate()) ? -1 : 1;
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindDayAccountResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindDayAccountResponse.java
@@ -34,7 +34,7 @@ public class FindDayAccountResponse implements Comparable<FindDayAccountResponse
 	 * 날짜 최신순으로 정렬
 	 * */
 	@Override
-	public int compareTo(FindDayAccountResponse r) {
-		return this.registerDate.isAfter(r.getRegisterDate()) ? -1 : 1;
+	public int compareTo(FindDayAccountResponse response) {
+		return this.registerDate.isAfter(response.getRegisterDate()) ? -1 : 1;
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/common/page/PageCustomImpl.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/common/page/PageCustomImpl.java
@@ -11,7 +11,7 @@ public class PageCustomImpl<T> extends ChunksCustom<T> {
 
 	private Integer nextPage;
 
-	public PageCustomImpl(int currentPage, PageCustomRequest pageRequest, List<T> results) {
+	public PageCustomImpl(PageCustomRequest pageRequest, List<T> results) {
 		super(results);
 		this.currentPage = pageRequest.getPage();
 		this.nextPage = this.currentPage + 1;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
@@ -114,6 +114,22 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 	class FindDayAccount {
 
 		@Test
+		public void 해당_페이징에_데이터가_없을때() {
+
+			PageCustomImpl<FindDayAccountResponse> dailyAccount = accountBookQueryRepository.findDailyAccount(
+				user.getId(),
+				new PageCustomRequest(1, 10),
+				LocalDate.parse("2022-08-01", DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+			);
+
+			List<FindDayAccountResponse> results = dailyAccount.getResults();
+
+			assertThat(results.size()).isEqualTo(0);
+			assertThat(dailyAccount.getCurrentPage()).isEqualTo(1);
+			assertThat(dailyAccount.getNextPage()).isNull();
+		}
+
+		@Test
 		public void 날짜를_수입과_집합의_날짜_합집합을_10개_반환하여_페이징처리한다() {
 			createExpenditures(10);
 			createIncomes(10);


### PR DESCRIPTION
쿼리 iterator 돌려서 일별 쿼리 날렸던거 데이트 범위로 날린 후 코드에서 해결
최대 32개 쿼리를 4개로 개선


## 변경전

- 재사용 고려하여 일별로 처리하던 것 데이트 범위로 묶어서 요청하여 쿼리 개수 개선

## 변경사항(Optional)

- 쿼리 개수 개선
- 정렬기준

FindDayAccountResponse는 날짜 최신순으로 정렬 기준
DayDetail은 지출 -> 수입, 그리고 최신순으로 정렬 기준을 정했습니다.


## TODO

- 8월 10일 이후 시간이 된다면 메서드 볼륨 리팩터 고려
- 향후 현재 작성한 것에 대한 controller 테스트 진행 예정
- 지난번 윌리엄 리뷰 다시 참고하여 반영할 부분 찾아서 수정해보기
