### PR TITLE
[#123] 카테고리 컨트롤러 통합 테스트 작성

### DIFF
--- a/src/test/java/com/prgrms/tenwonmoa/common/BaseControllerIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/BaseControllerIntegrationTest.java
@@ -1,0 +1,64 @@
+package com.prgrms.tenwonmoa.common;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class BaseControllerIntegrationTest {
+
+	@Autowired
+	protected MockMvc mvc;
+
+	protected ObjectMapper objectMapper = new ObjectMapper();
+
+	protected String token;
+
+	@BeforeEach
+	void registerUserAndLogin() throws Exception {
+		회원_등록();
+		로그인();
+	}
+
+	protected void 회원_등록() throws Exception {
+		ObjectNode userData = objectMapper.createObjectNode();
+		userData.put("email", "testuser@gmail.com");
+		userData.put("username", "testuser");
+		userData.put("password", "12345677");
+
+		mvc.perform(post("/api/v1/users")
+				.content(userData.toString())
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isCreated());
+	}
+
+	protected void 로그인() throws Exception {
+		ObjectNode loginUser = objectMapper.createObjectNode();
+		loginUser.put("email", "testuser@gmail.com");
+		loginUser.put("password", "12345677");
+
+		MockHttpServletResponse response = mvc.perform(post("/api/v1/users/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginUser.toString()))
+			.andExpect(status().isOk()).andReturn().getResponse();
+
+		String responseBody = response.getContentAsString();
+
+		JsonNode responseJson = objectMapper.readTree(responseBody);
+		token = "Bearer " + responseJson.get("accessToken").asText();
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/BaseControllerIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/BaseControllerIntegrationTest.java
@@ -26,7 +26,7 @@ public class BaseControllerIntegrationTest {
 
 	protected ObjectMapper objectMapper = new ObjectMapper();
 
-	protected String token;
+	protected String accessToken;
 
 	@BeforeEach
 	void registerUserAndLogin() throws Exception {
@@ -59,6 +59,6 @@ public class BaseControllerIntegrationTest {
 		String responseBody = response.getContentAsString();
 
 		JsonNode responseJson = objectMapper.readTree(responseBody);
-		token = "Bearer " + responseJson.get("accessToken").asText();
+		accessToken = "Bearer " + responseJson.get("accessToken").asText();
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerIntegrationTest.java
@@ -19,7 +19,7 @@ import com.prgrms.tenwonmoa.domain.category.dto.CreateCategoryRequest;
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-class UserCategoryControllerTest extends BaseControllerIntegrationTest {
+class UserCategoryControllerIntegrationTest extends BaseControllerIntegrationTest {
 
 	public static final String CATEGORY_URL_PREFIX = "/api/v1/categories";
 
@@ -27,7 +27,7 @@ class UserCategoryControllerTest extends BaseControllerIntegrationTest {
 	void 수입_카테고리_조회_Api() throws Exception {
 		mvc.perform(get(CATEGORY_URL_PREFIX)
 				.param("kind", "income")
-				.header(HttpHeaders.AUTHORIZATION, token))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpectAll(
 				status().isOk(),
 				jsonPath("$.categories[0].categoryType").value("INCOME"),
@@ -40,7 +40,7 @@ class UserCategoryControllerTest extends BaseControllerIntegrationTest {
 	void 지출_카테고리_조회_Api() throws Exception {
 		mvc.perform(get(CATEGORY_URL_PREFIX)
 				.param("kind", "expenditure")
-				.header(HttpHeaders.AUTHORIZATION, token))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpectAll(
 				status().isOk(),
 				jsonPath("$.categories[0].categoryType").value("EXPENDITURE"),
@@ -60,10 +60,10 @@ class UserCategoryControllerTest extends BaseControllerIntegrationTest {
 		mvc.perform(post(CATEGORY_URL_PREFIX)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(createCategoryRequest))
-				.header(HttpHeaders.AUTHORIZATION, token))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpectAll(
 				status().isCreated(),
-				jsonPath("$.id").value(any(Integer.class))
+				jsonPath("$.id").exists()
 			);
 	}
 
@@ -76,7 +76,7 @@ class UserCategoryControllerTest extends BaseControllerIntegrationTest {
 		String responseBody = mvc.perform(post(CATEGORY_URL_PREFIX)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(createCategoryRequest))
-				.header(HttpHeaders.AUTHORIZATION, token))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpect(status().isCreated()).andReturn().getResponse().getContentAsString();
 
 		long categoryId = objectMapper.readTree(responseBody).get("id").asLong();
@@ -86,7 +86,7 @@ class UserCategoryControllerTest extends BaseControllerIntegrationTest {
 		mvc.perform(patch(CATEGORY_URL_PREFIX + "/{categoryId}", categoryId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{\"name\" : \"수정된카테고리\"}")
-				.header(HttpHeaders.AUTHORIZATION, token))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpectAll(
 				status().isOk(),
 				jsonPath("$.name").value("수정된카테고리"));
@@ -101,7 +101,7 @@ class UserCategoryControllerTest extends BaseControllerIntegrationTest {
 		String responseBody = mvc.perform(post(CATEGORY_URL_PREFIX)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(createCategoryRequest))
-				.header(HttpHeaders.AUTHORIZATION, token))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpect(status().isCreated()).andReturn().getResponse().getContentAsString();
 
 		long categoryId = objectMapper.readTree(responseBody).get("id").asLong();
@@ -109,7 +109,7 @@ class UserCategoryControllerTest extends BaseControllerIntegrationTest {
 		//when
 		//then
 		mvc.perform(delete(CATEGORY_URL_PREFIX + "/{categoryId}", categoryId)
-				.header(HttpHeaders.AUTHORIZATION, token))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpect(status().isNoContent());
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerTest.java
@@ -1,197 +1,115 @@
 package com.prgrms.tenwonmoa.domain.category.controller;
 
-import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.prgrms.tenwonmoa.common.RestDocsConfig;
-import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
-import com.prgrms.tenwonmoa.config.JwtConfigure;
-import com.prgrms.tenwonmoa.config.WebSecurityConfig;
-import com.prgrms.tenwonmoa.domain.category.dto.FindCategoryResponse;
-import com.prgrms.tenwonmoa.domain.category.dto.FindCategoryResponse.SingleCategoryResponse;
-import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
-import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
-import com.prgrms.tenwonmoa.domain.user.User;
-import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
-import com.prgrms.tenwonmoa.domain.user.service.UserService;
+import com.prgrms.tenwonmoa.common.BaseControllerIntegrationTest;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.CategoryType;
+import com.prgrms.tenwonmoa.domain.category.dto.CreateCategoryRequest;
 
-@WebMvcTest(controllers = UserCategoryController.class,
-	excludeFilters = {
-		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class),
-		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtConfigure.class),
-		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
-	}
-)
-@MockBean(JpaMetamodelMappingContext.class)
-@ExtendWith(RestDocumentationExtension.class)
-@Import(RestDocsConfig.class)
-@DisplayName("유저 카테고리 컨트롤러 테스트")
-class UserCategoryControllerTest {
-	private static final String ENDPOINT_URL_PREFIX = "/api/v1/categories";
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class UserCategoryControllerTest extends BaseControllerIntegrationTest {
 
-	@Autowired
-	private RestDocumentationResultHandler restDocs;
-
-	@MockBean
-	private UserCategoryService userCategoryService;
-
-	@MockBean
-	private FindUserCategoryService findUserCategoryService;
-
-	@MockBean
-	private UserService userService;
-
-	private MockMvc mockMvc;
-
-	private final ObjectMapper objectMapper = new ObjectMapper();
-
-	private final User user = createUser();
-
-	@BeforeEach
-	void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
-		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-			.apply(MockMvcRestDocumentation.documentationConfiguration(provider))
-			.apply(springSecurity())
-			.alwaysDo(restDocs)
-			.addFilters(new CharacterEncodingFilter("UTF-8", true)) // 한글 깨짐 방지
-			.build();
-
-	}
+	public static final String CATEGORY_URL_PREFIX = "/api/v1/categories";
 
 	@Test
-	@WithMockCustomUser
-	void 카테고리_조회() throws Exception {
-		String categoryType = "EXPENDITURE";
-		given(findUserCategoryService.findUserCategories(anyLong(), eq(categoryType)))
-			.willReturn(new FindCategoryResponse(
-				List.of(new SingleCategoryResponse(1L, "식비", "EXPENDITURE"))));
-
-		mockMvc.perform(get(ENDPOINT_URL_PREFIX).queryParam("kind", categoryType))
-			.andExpect(status().isOk())
-			.andDo(
-				restDocs.document(
-					requestParameters(
-						parameterWithName("kind").description("카테고리 종류")
-					),
-					responseFields(
-						fieldWithPath("categories[].id").type(JsonFieldType.NUMBER).description("카테고리 아이디"),
-						fieldWithPath("categories[].name").type(JsonFieldType.STRING).description("카테고리 이름"),
-						fieldWithPath("categories[].categoryType").type(JsonFieldType.STRING).description("카테고리 종류")
-					)
-				)
+	void 수입_카테고리_조회_Api() throws Exception {
+		mvc.perform(get(CATEGORY_URL_PREFIX)
+				.param("kind", "income")
+				.header(HttpHeaders.AUTHORIZATION, token))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.categories[0].categoryType").value("INCOME"),
+				jsonPath("$.categories",
+					hasSize(Category.DEFAULT_CATEGORY.get(CategoryType.INCOME).size()))
 			);
 	}
 
 	@Test
-	@WithMockCustomUser
-	void 카테고리_등록() throws Exception {
-		Long userCategoryId = 1L;
-		String categoryType = "EXPENDITURE";
-		String categoryName = "교통비";
+	void 지출_카테고리_조회_Api() throws Exception {
+		mvc.perform(get(CATEGORY_URL_PREFIX)
+				.param("kind", "expenditure")
+				.header(HttpHeaders.AUTHORIZATION, token))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.categories[0].categoryType").value("EXPENDITURE"),
+				jsonPath("$.categories",
+					hasSize(Category.DEFAULT_CATEGORY.get(CategoryType.EXPENDITURE).size()))
+			);
+	}
 
-		ObjectNode body = objectMapper.createObjectNode();
-		body.put("categoryType", categoryType);
-		body.put("name", categoryName);
+	@Test
+	void 카테고리_등록_Api() throws Exception {
+		//given
+		CreateCategoryRequest createCategoryRequest
+			= new CreateCategoryRequest("INCOME", "수입카테고리");
 
-		given(userCategoryService.createUserCategory(user, categoryType, categoryName)).willReturn(userCategoryId);
-
-		mockMvc.perform(post(ENDPOINT_URL_PREFIX)
+		//when
+		//then
+		mvc.perform(post(CATEGORY_URL_PREFIX)
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(body.toString())
-				.with(csrf()))
-			.andExpect(status().isCreated())
-			.andDo(
-				restDocs.document(
-					requestFields(
-						fieldWithPath("categoryType").type(JsonFieldType.STRING).description("카테고리 타입(수입/지출)"),
-						fieldWithPath("name").type(JsonFieldType.STRING).description("카테고리 이름")
-					),
-					responseFields(
-						fieldWithPath("id").type(JsonFieldType.NUMBER).description("생성된 카테고리 아이디")
-					)
-				)
+				.content(objectMapper.writeValueAsString(createCategoryRequest))
+				.header(HttpHeaders.AUTHORIZATION, token))
+			.andExpectAll(
+				status().isCreated(),
+				jsonPath("$.id").value(any(Integer.class))
 			);
 	}
 
 	@Test
-	@WithMockCustomUser
-	void 카테고리_수정() throws Exception {
-		Long userCategoryId = 1L;
-		String updateName = "수정된 분류이름";
+	void 카테고리_수정_Api() throws Exception {
+		//given
+		CreateCategoryRequest createCategoryRequest
+			= new CreateCategoryRequest("INCOME", "수입카테고리");
 
-		ObjectNode body = objectMapper.createObjectNode();
-		body.put("name", updateName);
+		String responseBody = mvc.perform(post(CATEGORY_URL_PREFIX)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createCategoryRequest))
+				.header(HttpHeaders.AUTHORIZATION, token))
+			.andExpect(status().isCreated()).andReturn().getResponse().getContentAsString();
 
-		given(userService.findById(anyLong())).willReturn(user);
-		given(userCategoryService.updateName(user, userCategoryId, updateName)).willReturn(updateName);
+		long categoryId = objectMapper.readTree(responseBody).get("id").asLong();
 
-		mockMvc.perform(patch(ENDPOINT_URL_PREFIX + "/{userCategoryId}", userCategoryId)
-				.with(csrf())
-				.content(body.toString())
-				.contentType(MediaType.APPLICATION_JSON))
-			.andExpect(status().isOk())
-			.andDo(
-				restDocs.document(
-					requestFields(
-						fieldWithPath("name").type(JsonFieldType.STRING).description("업데이트할 카테고리 이름")
-					),
-					responseFields(
-						fieldWithPath("name").type(JsonFieldType.STRING).description("업데이트 된 카테고리 이름")
-					)
-				)
-			);
+		//when
+		//then
+		mvc.perform(patch(CATEGORY_URL_PREFIX + "/{categoryId}", categoryId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\" : \"수정된카테고리\"}")
+				.header(HttpHeaders.AUTHORIZATION, token))
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.name").value("수정된카테고리"));
 	}
 
 	@Test
-	@WithMockCustomUser
-	void 카테고리_삭제() throws Exception {
-		Long userCategoryId = 1L;
+	void 카테고리_삭제_Api() throws Exception {
+		//given
+		CreateCategoryRequest createCategoryRequest
+			= new CreateCategoryRequest("INCOME", "수입카테고리");
 
-		given(userService.findById(anyLong())).willReturn(user);
+		String responseBody = mvc.perform(post(CATEGORY_URL_PREFIX)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createCategoryRequest))
+				.header(HttpHeaders.AUTHORIZATION, token))
+			.andExpect(status().isCreated()).andReturn().getResponse().getContentAsString();
 
-		mockMvc.perform(
-				RestDocumentationRequestBuilders.delete(ENDPOINT_URL_PREFIX + "/{userCategoryId}", userCategoryId)
-					.with(csrf()))
-			.andExpect(status().isNoContent())
-			.andDo(
-				restDocs.document(
-					pathParameters(parameterWithName("userCategoryId").description("카테고리 아이디"))
-				)
-			);
-		verify(userCategoryService).deleteUserCategory(user, userCategoryId);
+		long categoryId = objectMapper.readTree(responseBody).get("id").asLong();
+
+		//when
+		//then
+		mvc.perform(delete(CATEGORY_URL_PREFIX + "/{categoryId}", categoryId)
+				.header(HttpHeaders.AUTHORIZATION, token))
+			.andExpect(status().isNoContent());
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerUnitTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerUnitTest.java
@@ -1,0 +1,197 @@
+package com.prgrms.tenwonmoa.domain.category.controller;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.prgrms.tenwonmoa.common.RestDocsConfig;
+import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
+import com.prgrms.tenwonmoa.config.JwtConfigure;
+import com.prgrms.tenwonmoa.config.WebSecurityConfig;
+import com.prgrms.tenwonmoa.domain.category.dto.FindCategoryResponse;
+import com.prgrms.tenwonmoa.domain.category.dto.FindCategoryResponse.SingleCategoryResponse;
+import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
+import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
+import com.prgrms.tenwonmoa.domain.user.service.UserService;
+
+@WebMvcTest(controllers = UserCategoryController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtConfigure.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+	}
+)
+@MockBean(JpaMetamodelMappingContext.class)
+@ExtendWith(RestDocumentationExtension.class)
+@Import(RestDocsConfig.class)
+@DisplayName("유저 카테고리 컨트롤러 테스트")
+class UserCategoryControllerUnitTest {
+	private static final String ENDPOINT_URL_PREFIX = "/api/v1/categories";
+
+	@Autowired
+	private RestDocumentationResultHandler restDocs;
+
+	@MockBean
+	private UserCategoryService userCategoryService;
+
+	@MockBean
+	private FindUserCategoryService findUserCategoryService;
+
+	@MockBean
+	private UserService userService;
+
+	private MockMvc mockMvc;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	private final User user = createUser();
+
+	@BeforeEach
+	void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+			.apply(springSecurity())
+			.alwaysDo(restDocs)
+			.addFilters(new CharacterEncodingFilter("UTF-8", true)) // 한글 깨짐 방지
+			.build();
+
+	}
+
+	@Test
+	@WithMockCustomUser
+	void 카테고리_조회() throws Exception {
+		String categoryType = "EXPENDITURE";
+		given(findUserCategoryService.findUserCategories(anyLong(), eq(categoryType)))
+			.willReturn(new FindCategoryResponse(
+				List.of(new SingleCategoryResponse(1L, "식비", "EXPENDITURE"))));
+
+		mockMvc.perform(get(ENDPOINT_URL_PREFIX).queryParam("kind", categoryType))
+			.andExpect(status().isOk())
+			.andDo(
+				restDocs.document(
+					requestParameters(
+						parameterWithName("kind").description("카테고리 종류")
+					),
+					responseFields(
+						fieldWithPath("categories[].id").type(JsonFieldType.NUMBER).description("카테고리 아이디"),
+						fieldWithPath("categories[].name").type(JsonFieldType.STRING).description("카테고리 이름"),
+						fieldWithPath("categories[].categoryType").type(JsonFieldType.STRING).description("카테고리 종류")
+					)
+				)
+			);
+	}
+
+	@Test
+	@WithMockCustomUser
+	void 카테고리_등록() throws Exception {
+		Long userCategoryId = 1L;
+		String categoryType = "EXPENDITURE";
+		String categoryName = "교통비";
+
+		ObjectNode body = objectMapper.createObjectNode();
+		body.put("categoryType", categoryType);
+		body.put("name", categoryName);
+
+		given(userCategoryService.createUserCategory(user, categoryType, categoryName)).willReturn(userCategoryId);
+
+		mockMvc.perform(post(ENDPOINT_URL_PREFIX)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(body.toString())
+				.with(csrf()))
+			.andExpect(status().isCreated())
+			.andDo(
+				restDocs.document(
+					requestFields(
+						fieldWithPath("categoryType").type(JsonFieldType.STRING).description("카테고리 타입(수입/지출)"),
+						fieldWithPath("name").type(JsonFieldType.STRING).description("카테고리 이름")
+					),
+					responseFields(
+						fieldWithPath("id").type(JsonFieldType.NUMBER).description("생성된 카테고리 아이디")
+					)
+				)
+			);
+	}
+
+	@Test
+	@WithMockCustomUser
+	void 카테고리_수정() throws Exception {
+		Long userCategoryId = 1L;
+		String updateName = "수정된 분류이름";
+
+		ObjectNode body = objectMapper.createObjectNode();
+		body.put("name", updateName);
+
+		given(userService.findById(anyLong())).willReturn(user);
+		given(userCategoryService.updateName(user, userCategoryId, updateName)).willReturn(updateName);
+
+		mockMvc.perform(patch(ENDPOINT_URL_PREFIX + "/{userCategoryId}", userCategoryId)
+				.with(csrf())
+				.content(body.toString())
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(
+				restDocs.document(
+					requestFields(
+						fieldWithPath("name").type(JsonFieldType.STRING).description("업데이트할 카테고리 이름")
+					),
+					responseFields(
+						fieldWithPath("name").type(JsonFieldType.STRING).description("업데이트 된 카테고리 이름")
+					)
+				)
+			);
+	}
+
+	@Test
+	@WithMockCustomUser
+	void 카테고리_삭제() throws Exception {
+		Long userCategoryId = 1L;
+
+		given(userService.findById(anyLong())).willReturn(user);
+
+		mockMvc.perform(
+				RestDocumentationRequestBuilders.delete(ENDPOINT_URL_PREFIX + "/{userCategoryId}", userCategoryId)
+					.with(csrf()))
+			.andExpect(status().isNoContent())
+			.andDo(
+				restDocs.document(
+					pathParameters(parameterWithName("userCategoryId").description("카테고리 아이디"))
+				)
+			);
+		verify(userCategoryService).deleteUserCategory(user, userCategoryId);
+	}
+}


### PR DESCRIPTION
## 개요
- 컨트롤러 통합 테스트를 위한 BaseControllerIntegrationTest클래스와 카테고리 컨트롤러 통합 테스트 작성

## 추가기능
- 로그인(), 회원_등록() api를 BaseControllerIntegrationTest에 작성하여 BeforeEach 적용 -> 모든 @Test에서 자동적으로 실행됨

## 사용방법(Optional)

- BeforeEach에서 회원_등록(), 로그인() 이 호출되면서 `token` field에 jwt token 값이 셋팅됨
- 해당 jwt token을 mockMvc.header() 로 지정하고 API 호출 테스트 작성하면 됨 
