### PR TITLE
[#128] 수입 컨트롤러 통합테스트 작성

### DIFF
--- a/src/test/java/com/prgrms/tenwonmoa/common/BaseControllerIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/BaseControllerIntegrationTest.java
@@ -3,14 +3,12 @@ package com.prgrms.tenwonmoa.common;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,18 +16,17 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Transactional
 public class BaseControllerIntegrationTest {
 
 	@Autowired
 	protected MockMvc mvc;
 
-	protected ObjectMapper objectMapper = new ObjectMapper();
+	@Autowired
+	protected ObjectMapper objectMapper;
 
 	protected String accessToken;
 
-	@BeforeEach
-	void registerUserAndLogin() throws Exception {
+	protected void registerUserAndLogin() throws Exception {
 		회원_등록();
 		로그인();
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeIntegrationTest.java
@@ -79,7 +79,7 @@ class IncomeIntegrationTest extends BaseControllerIntegrationTest {
 	void 수입_등록_Valid_등록일() throws Exception {
 		CreateIncomeRequest request = new CreateIncomeRequest(null, 2000L, "content2", userCategory.getId());
 
-		validCreateRequest(request, "등록일을 채워주세요");
+		validateCreateRequest(request, "등록일을 채워주세요");
 	}
 
 	@Test
@@ -90,8 +90,8 @@ class IncomeIntegrationTest extends BaseControllerIntegrationTest {
 		CreateIncomeRequest requestMax = new CreateIncomeRequest(LocalDateTime.now(), 1_000_000_000_001L, "content2",
 			userCategory.getId());
 
-		validCreateRequest(requestMin, "최소값은 0입니다");
-		validCreateRequest(requestMax, "최대값은 1조입니다");
+		validateCreateRequest(requestMin, "최소값은 0입니다");
+		validateCreateRequest(requestMax, "최대값은 1조입니다");
 	}
 
 	@Test
@@ -99,14 +99,14 @@ class IncomeIntegrationTest extends BaseControllerIntegrationTest {
 		CreateIncomeRequest request = new CreateIncomeRequest(LocalDateTime.now(), 1000L, RandomString.make(51),
 			userCategory.getId());
 
-		validCreateRequest(request, "내용의 최대 길이는 50입니다");
+		validateCreateRequest(request, "내용의 최대 길이는 50입니다");
 	}
 
 	@Test
 	void 수입_등록_Valid_카테고리_ID() throws Exception {
 		CreateIncomeRequest request = new CreateIncomeRequest(LocalDateTime.now(), 1000L, "content", null);
 
-		validCreateRequest(request, "유저 카테고리 아이디를 채워주세요");
+		validateCreateRequest(request, "유저 카테고리 아이디를 채워주세요");
 	}
 
 	@Test
@@ -171,7 +171,7 @@ class IncomeIntegrationTest extends BaseControllerIntegrationTest {
 		assertThat(findIncome).isEmpty();
 	}
 
-	private void validCreateRequest(CreateIncomeRequest request, String expectMessage) throws Exception {
+	private void validateCreateRequest(CreateIncomeRequest request, String expectMessage) throws Exception {
 		mvc.perform(post(LOCATION_PREFIX).contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request))
 				.header(HttpHeaders.AUTHORIZATION, accessToken))

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeIntegrationTest.java
@@ -1,0 +1,181 @@
+package com.prgrms.tenwonmoa.domain.accountbook.controller;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static com.prgrms.tenwonmoa.domain.category.CategoryType.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import net.bytebuddy.utility.RandomString;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.tenwonmoa.common.BaseControllerIntegrationTest;
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.income.CreateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.income.UpdateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.category.repository.CategoryRepository;
+import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
+
+@DisplayName("수입 컨트롤러 통합 테스트")
+class IncomeIntegrationTest extends BaseControllerIntegrationTest {
+	private static final String LOCATION_PREFIX = "/api/v1/incomes/";
+
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private UserCategoryRepository userCategoryRepository;
+	@Autowired
+	private IncomeRepository incomeRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private ExpenditureRepository expenditureRepository;
+
+	private User loginUser;
+	private Category category;
+	private UserCategory userCategory;
+	private Income income;
+
+	@BeforeEach
+	void init() throws Exception {
+		registerUserAndLogin();
+		loginUser = userRepository.findByEmail("testuser@gmail.com").get();
+		category = categoryRepository.save(createIncomeCategory());
+		userCategory = userCategoryRepository.save(createUserCategory(loginUser, category));
+		income = incomeRepository.save(createIncome(userCategory));
+	}
+
+	@AfterEach
+	void clear() {
+		incomeRepository.deleteAllInBatch();
+		expenditureRepository.deleteAllInBatch();
+		userCategoryRepository.deleteAllInBatch();
+		userRepository.deleteAllInBatch();
+		categoryRepository.deleteAllInBatch();
+	}
+
+	@Test
+	void 수입_등록_Valid_등록일() throws Exception {
+		CreateIncomeRequest request = new CreateIncomeRequest(null, 2000L, "content2", userCategory.getId());
+
+		validCreateRequest(request, "등록일을 채워주세요");
+	}
+
+	@Test
+	void 수입_등록_Valid_금액() throws Exception {
+		CreateIncomeRequest requestMin = new CreateIncomeRequest(LocalDateTime.now(), -1L, "content2",
+			userCategory.getId());
+
+		CreateIncomeRequest requestMax = new CreateIncomeRequest(LocalDateTime.now(), 1_000_000_000_001L, "content2",
+			userCategory.getId());
+
+		validCreateRequest(requestMin, "최소값은 0입니다");
+		validCreateRequest(requestMax, "최대값은 1조입니다");
+	}
+
+	@Test
+	void 수입_등록_Valid_내용() throws Exception {
+		CreateIncomeRequest request = new CreateIncomeRequest(LocalDateTime.now(), 1000L, RandomString.make(51),
+			userCategory.getId());
+
+		validCreateRequest(request, "내용의 최대 길이는 50입니다");
+	}
+
+	@Test
+	void 수입_등록_Valid_카테고리_ID() throws Exception {
+		CreateIncomeRequest request = new CreateIncomeRequest(LocalDateTime.now(), 1000L, "content", null);
+
+		validCreateRequest(request, "유저 카테고리 아이디를 채워주세요");
+	}
+
+	@Test
+	void 수입_등록_성공() throws Exception {
+		CreateIncomeRequest request = new CreateIncomeRequest(LocalDateTime.now(), 2000L, "content2",
+			userCategory.getId());
+
+		mvc.perform(post(LOCATION_PREFIX).contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("id").exists());
+	}
+
+	@Test
+	void 수입_상세조회_성공() throws Exception {
+		mvc.perform(get(LOCATION_PREFIX + "/{incomeId}", income.getId()).header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("id").value(income.getId()))
+			.andExpect(jsonPath("registerDate").value(income.getRegisterDate().toString()))
+			.andExpect(jsonPath("amount").value(income.getAmount()))
+			.andExpect(jsonPath("content").value(income.getContent()))
+			.andExpect(jsonPath("userCategoryId").value(income.getUserCategory().getId()))
+			.andExpect(jsonPath("categoryName").value(userCategory.getCategoryName()));
+	}
+
+	@Test
+	void 수입_수정_성공() throws Exception {
+		Category otherCategory = categoryRepository.save(new Category("다른 카테고리", INCOME));
+		UserCategory otherUserCategory = userCategoryRepository.save(createUserCategory(loginUser, otherCategory));
+
+		UpdateIncomeRequest updateIncomeRequest = new UpdateIncomeRequest(LocalDateTime.now(), 2000L, "updateContent",
+			otherUserCategory.getId());
+
+		mvc.perform(put(LOCATION_PREFIX + "/{incomeId}", income.getId()).contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(updateIncomeRequest))
+			.header(HttpHeaders.AUTHORIZATION, accessToken)).andExpect(status().isNoContent());
+
+		Optional<Income> findIncome = incomeRepository.findById(income.getId());
+
+		assertThat(findIncome).isPresent();
+
+		Income getIncome = findIncome.get();
+		assertThat(getIncome.getAmount()).isEqualTo(updateIncomeRequest.getAmount());
+		assertThat(getIncome.getContent()).isEqualTo(updateIncomeRequest.getContent());
+		assertThat(getIncome.getUserCategory().getId()).isEqualTo(updateIncomeRequest.getUserCategoryId());
+	}
+
+	@Test
+	void 수입에서_지출로_변경() throws Exception {
+		Category otherCategory = categoryRepository.save(new Category("다른 카테고리", EXPENDITURE));
+		UserCategory otherUserCategory = userCategoryRepository.save(createUserCategory(loginUser, otherCategory));
+
+		UpdateIncomeRequest updateIncomeRequest = new UpdateIncomeRequest(LocalDateTime.now(), 2000L, "updateContent",
+			otherUserCategory.getId());
+
+		mvc.perform(put(LOCATION_PREFIX + "/{incomeId}", income.getId()).contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(updateIncomeRequest))
+			.header(HttpHeaders.AUTHORIZATION, accessToken)).andExpect(status().isNoContent());
+
+		Optional<Income> findIncome = incomeRepository.findById(income.getId());
+		assertThat(findIncome).isEmpty();
+	}
+
+	private void validCreateRequest(CreateIncomeRequest request, String expectMessage) throws Exception {
+		mvc.perform(post(LOCATION_PREFIX).contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("messages").value(expectMessage));
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/controller/UserCategoryControllerIntegrationTest.java
@@ -4,9 +4,8 @@ import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,11 +14,13 @@ import com.prgrms.tenwonmoa.common.BaseControllerIntegrationTest;
 import com.prgrms.tenwonmoa.domain.category.Category;
 import com.prgrms.tenwonmoa.domain.category.CategoryType;
 import com.prgrms.tenwonmoa.domain.category.dto.CreateCategoryRequest;
-
-@SpringBootTest
-@AutoConfigureMockMvc
 @Transactional
 class UserCategoryControllerIntegrationTest extends BaseControllerIntegrationTest {
+
+	@BeforeEach
+	void init() throws Exception {
+		registerUserAndLogin();
+	}
 
 	public static final String CATEGORY_URL_PREFIX = "/api/v1/categories";
 


### PR DESCRIPTION
## 개요
- 수입 컨트롤러 통합테스트 작성


## 변경사항(Optional)

- 해당 [PR](https://github.com/prgrms-web-devcourse/Team-10jo-10wonmoa-BE/pull/124) 에서 윌리엄이 추가해주신  통합 공통 테스트에서 @BeforeEach와 @Transactional을 제거했습니다.

## 기타
- [@Transactional을 Test코드에 작성할 경우](https://tecoble.techcourse.co.kr/post/2020-08-31-jpa-transaction-test/), 실제 코드에 @Transactional 누락되는 경우를 체크하기 어렵고, 트랜잭션 전파로 의도치 않은 동작이 처리되는 경험을 하여, 저는 통합테스트 작성시 @Transactional을 지양하려 합니다.
- 그러한 이유로 이번 통합테스트에서도 @BeforeEach와 @AfterEach를 통해 진행했습니다.
