### PR TITLE
[#130] 통계 데이터 조회 쿼리구현

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsData.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsData.java
@@ -1,11 +1,13 @@
 package com.prgrms.tenwonmoa.domain.accountbook.dto.statistics;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @Getter
+@RequiredArgsConstructor
 @ToString
 public class FindStatisticsData {
-	String name;
-	Long total;
+	private String name;
+	private Long total;
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsData.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsData.java
@@ -1,0 +1,11 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto.statistics;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class FindStatisticsData {
+	String name;
+	Long total;
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepository.java
@@ -1,0 +1,87 @@
+package com.prgrms.tenwonmoa.domain.accountbook.repository;
+
+import static com.prgrms.tenwonmoa.domain.accountbook.QExpenditure.*;
+import static com.prgrms.tenwonmoa.domain.accountbook.QIncome.*;
+import static com.prgrms.tenwonmoa.domain.category.QCategory.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsData;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class StatisticsQueryRepository {
+	private static final String NEED_TO_YEAR_WHEN_MONTH = "월 조건은 년도가 반드시 입력되어야 합니다.";
+	private static final String NAME = "name";
+	private static final String TOTAL = "total";
+	private static final StringPath NAME_ALIAS = Expressions.stringPath(NAME);
+	private static final NumberPath<Long> TOTAL_ALIAS = Expressions.numberPath(Long.class, TOTAL);
+
+	private final JPAQueryFactory queryFactory;
+
+	public List<FindStatisticsData> searchIncomeByRegisterDate(Long userId, Integer year, Integer month) {
+		return queryFactory.select(Projections.fields(FindStatisticsData.class,
+				category.name.coalesce(income.categoryName).as(NAME),
+				income.amount.sum().as(TOTAL)
+			))
+			.from(income)
+			.leftJoin(income.userCategory.category, category)
+			.where(yearMonthEqIncome(year, month), income.user.id.eq(userId))
+			.groupBy(NAME_ALIAS)
+			.orderBy(TOTAL_ALIAS.desc())
+			.fetch();
+	}
+
+	public List<FindStatisticsData> searchExpenditureByRegisterDate(Long userId, Integer year, Integer month) {
+		return queryFactory.select(Projections.fields(FindStatisticsData.class,
+				category.name.coalesce(expenditure.categoryName).as(NAME),
+				expenditure.amount.sum().as(TOTAL)
+			))
+			.from(expenditure)
+			.leftJoin(expenditure.userCategory.category, category)
+			.where(yearMonthEqExpenditure(year, month), expenditure.user.id.eq(userId))
+			.groupBy(NAME_ALIAS)
+			.orderBy(TOTAL_ALIAS.desc())
+			.fetch();
+	}
+
+	private BooleanExpression yearMonthEqIncome(Integer year, Integer month) {
+		if (month != null && year == null) {
+			throw new IllegalArgumentException(NEED_TO_YEAR_WHEN_MONTH);
+		}
+		return yearEqIncome(year).and(monthEqIncome(month));
+	}
+
+	private BooleanExpression monthEqIncome(Integer month) {
+		return month != null ? income.registerDate.month().eq(month) : null;
+	}
+
+	private BooleanExpression yearEqIncome(Integer year) {
+		return year != null ? income.registerDate.year().eq(year) : null;
+	}
+
+	private BooleanExpression yearMonthEqExpenditure(Integer year, Integer month) {
+		if (month != null && year == null) {
+			throw new IllegalArgumentException(NEED_TO_YEAR_WHEN_MONTH);
+		}
+		return yearEqExpenditure(year).and(monthEqExpenditure(month));
+	}
+
+	private BooleanExpression monthEqExpenditure(Integer month) {
+		return month != null ? expenditure.registerDate.month().eq(month) : null;
+	}
+
+	private BooleanExpression yearEqExpenditure(Integer year) {
+		return year != null ? expenditure.registerDate.year().eq(year) : null;
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
@@ -3,8 +3,11 @@ package com.prgrms.tenwonmoa.common.fixture;
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
 
 import java.time.LocalDateTime;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
 
 import com.prgrms.tenwonmoa.common.RepositoryTest;
+import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.category.Category;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
@@ -24,13 +27,31 @@ public class RepositoryFixture extends RepositoryTest {
 		return save(new UserCategory(saveRandomUser(), saveIncomeCategory()));
 	}
 
+	public UserCategory saveUserCategory(User user, Category category) {
+		return save(new UserCategory(user, category));
+	}
+
 	public Income saveIncome() {
 		UserCategory userCategory = saveUserCategory();
-		return save(new Income(LocalDateTime.now(),
-			1000L,
-			"content",
-			userCategory.getCategory().getName(),
-			userCategory.getUser(),
+		return save(new Income(LocalDateTime.now(), 1000L, "content", userCategory.getCategory().getName(),
+			userCategory.getUser(), userCategory));
+	}
+
+	public Income saveIncome(UserCategory userCategory, Long amount, LocalDateTime registerDate) {
+		return save(new Income(registerDate, amount, "content", userCategory.getCategoryName(), userCategory.getUser(),
 			userCategory));
+	}
+
+	public Expenditure saveExpenditure(UserCategory userCategory, Long amount, LocalDateTime registerDate) {
+		return save(
+			new Expenditure(registerDate, amount, "content", userCategory.getCategoryName(), userCategory.getUser(),
+				userCategory));
+	}
+
+	public void iterateFixture(int count, IntConsumer function) {
+		count++;
+		IntStream.range(1, count).forEach(i -> {
+			function.accept(i);
+		});
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
@@ -205,15 +205,15 @@ class StatisticsQueryRepositoryTest extends RepositoryFixture {
 		expenditureUserCategory2 = saveUserCategory(user, expenditureCategory2);
 		UserCategory expenditureUserCategory3 = saveUserCategory(user, expenditureCategory3);
 
-		// 2022.07월달에 category1으로 1건의 수입등록
+		// 2022.07월달에 category1으로 1건의 지출등록
 		iterateFixture(1, (i) -> saveExpenditure(expenditureUserCategory1, AMOUNT, of(2022, 7, i, 0, 0, 0)));
-		// 2022.07월달에 category2으로 2건의 수입등록
+		// 2022.07월달에 category2으로 2건의 지출등록
 		iterateFixture(2, (i) -> saveExpenditure(expenditureUserCategory2, AMOUNT, of(2022, 7, i, 0, 0, 0)));
-		// 2022.07월달에 category3으로 3건의 수입등록
+		// 2022.07월달에 category3으로 3건의 지출등록
 		iterateFixture(3, (i) -> saveExpenditure(expenditureUserCategory3, AMOUNT, of(2022, 7, i, 0, 0, 0)));
-		// 2022.06월달에 category1으로 2건의 수입등록
+		// 2022.06월달에 category1으로 2건의 지출등록
 		iterateFixture(2, (i) -> saveExpenditure(expenditureUserCategory1, AMOUNT, of(2022, 6, i, 0, 0, 0)));
-		// 2021.07월달에 category1으로 2건의 수입등록
+		// 2021.07월달에 category1으로 2건의 지출등록
 		iterateFixture(2, (i) -> saveExpenditure(expenditureUserCategory1, AMOUNT, of(2022, 2, i, 0, 0, 0)));
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
@@ -18,7 +18,6 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsData
 import com.prgrms.tenwonmoa.domain.category.Category;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 
 class StatisticsQueryRepositoryTest extends RepositoryFixture {
 	private static final String NAME = "name";
@@ -39,16 +38,16 @@ class StatisticsQueryRepositoryTest extends RepositoryFixture {
 	@BeforeEach
 	void init() {
 		user = saveRandomUser();
-
 		initIncomeData();
 		initExpenditureData();
 	}
 
 	@Test
 	void 수입_월조건통계조회_성공() {
+		// when
 		List<FindStatisticsData> incomes = statisticsQueryRepository
 			.searchIncomeByRegisterDate(user.getId(), 2022, 07);
-
+		// then
 		assertThat(incomes).hasSize(3);
 		assertThat(incomes).extracting(NAME)
 			.containsExactly(INCOME_DEFAULT.get(0), INCOME_DEFAULT.get(1), INCOME_DEFAULT.get(2));
@@ -64,55 +63,53 @@ class StatisticsQueryRepositoryTest extends RepositoryFixture {
 
 	@Test
 	void 수입_년조건_통계_월_null_일때_성공() {
+		// when
 		List<FindStatisticsData> findStatisticsData = statisticsQueryRepository.searchIncomeByRegisterDate(user.getId(),
 			2022,
 			null);
+		// then
 		assertThat(findStatisticsData).hasSize(3);
 	}
 
 	@Test
 	void 유저카테고리_삭제시_카테고리의이름을_참조한다() {
-		// userCategory2 삭제
+		// given
 		UserCategory findUserCategory2 = em.find(UserCategory.class, incomeUserCategory2.getId());
 		findUserCategory2.updateCategoryAsNull();
 		save(findUserCategory2);
-
+		// when
 		List<FindStatisticsData> incomes = statisticsQueryRepository
 			.searchIncomeByRegisterDate(user.getId(), 2022, 07);
+		// then
 		assertThat(incomes).hasSize(3);
 		assertThat(incomes).extracting(NAME)
 			.containsExactly(INCOME_DEFAULT.get(0), INCOME_DEFAULT.get(1), INCOME_DEFAULT.get(2));
 		assertThat(incomes).extracting(NAME)
 			.doesNotContainNull();
 	}
-
 	@Test
 	void 카테고리이름_변경시_변경된이름을_참조한다() {
-		// category3의 이름변경
+		// given
 		Category findCategory3 = em.find(Category.class, incomeCategory3.getId());
 		String updateCategoryName = "KAN-TE";
 		findCategory3.updateName(updateCategoryName);
 		save(findCategory3);
-
+		// when
 		List<FindStatisticsData> incomes = statisticsQueryRepository
 			.searchIncomeByRegisterDate(user.getId(), 2022, 07);
+		// then
 		assertThat(incomes).hasSize(3);
 		assertThat(incomes).extracting(NAME)
 			.containsExactly(INCOME_DEFAULT.get(0), INCOME_DEFAULT.get(1), updateCategoryName);
 		assertThat(incomes).extracting(NAME)
 			.doesNotContain(INCOME_DEFAULT.get(2));
 	}
-
-	// 000000
-
 	@Test
 	void 지출_월조건통계조회_성공() {
+		// when
 		List<FindStatisticsData> findData = statisticsQueryRepository
 			.searchExpenditureByRegisterDate(user.getId(), 2022, 07);
-
-		for (FindStatisticsData d : findData) {
-			System.out.println(d);
-		}
+		// then
 		assertThat(findData).hasSize(3);
 		assertThat(findData).extracting(NAME)
 			.containsExactly(EXPENDITURE_DEFAULT.get(2), EXPENDITURE_DEFAULT.get(1), EXPENDITURE_DEFAULT.get(0));
@@ -137,13 +134,14 @@ class StatisticsQueryRepositoryTest extends RepositoryFixture {
 
 	@Test
 	void 지출_유저카테고리_삭제시_카테고리의이름을_참조한다() {
-		// userCategory2 삭제
+		// given
 		UserCategory findUserCategory2 = em.find(UserCategory.class, expenditureUserCategory2.getId());
 		findUserCategory2.updateCategoryAsNull();
 		save(findUserCategory2);
-
+		// when
 		List<FindStatisticsData> findData = statisticsQueryRepository
 			.searchExpenditureByRegisterDate(user.getId(), 2022, 07);
+		// then
 		assertThat(findData).hasSize(3);
 		assertThat(findData).extracting(NAME)
 			.containsExactly(EXPENDITURE_DEFAULT.get(2), EXPENDITURE_DEFAULT.get(1), EXPENDITURE_DEFAULT.get(0));
@@ -153,14 +151,15 @@ class StatisticsQueryRepositoryTest extends RepositoryFixture {
 
 	@Test
 	void 지출_카테고리이름_변경시_변경된이름을_참조한다() {
-		// category3의 이름변경
+		// given
 		Category findCategory3 = em.find(Category.class, expenditureCategory3.getId());
 		String updateCategoryName = "KAN-TE";
 		findCategory3.updateName(updateCategoryName);
 		save(findCategory3);
-
+		// when
 		List<FindStatisticsData> findData = statisticsQueryRepository
 			.searchExpenditureByRegisterDate(user.getId(), 2022, 07);
+		// then
 		assertThat(findData).hasSize(3);
 		assertThat(findData).extracting(NAME)
 			.containsExactly(updateCategoryName, EXPENDITURE_DEFAULT.get(1), EXPENDITURE_DEFAULT.get(0));

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
@@ -21,30 +21,23 @@ import com.prgrms.tenwonmoa.domain.user.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 class StatisticsQueryRepositoryTest extends RepositoryFixture {
-	private static final String NEED_TO_YEAR_WHEN_MONTH = "월 조건은 년도가 반드시 입력되어야 합니다.";
-	public static final String NAME = "name";
-	public static final String TOTAL = "total";
-
+	private static final String NAME = "name";
+	private static final String TOTAL = "total";
 	private static final List<String> INCOME_DEFAULT = List.of("용돈", "상여", "금융소득");
 	private static final List<String> EXPENDITURE_DEFAULT = List.of("교통/차량", "문화생활", "마트/편의점");
 	private static final Long AMOUNT = 10L;
-
 	@Autowired
 	EntityManager em;
-	JPAQueryFactory queryFactory;
-	User user;
-
 	@Autowired
 	StatisticsQueryRepository statisticsQueryRepository;
+	User user;
 	UserCategory incomeUserCategory2;
 	Category incomeCategory3;
-
 	UserCategory expenditureUserCategory2;
 	Category expenditureCategory3;
 
 	@BeforeEach
 	void init() {
-		queryFactory = new JPAQueryFactory(em);
 		user = saveRandomUser();
 
 		initIncomeData();

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
@@ -1,0 +1,219 @@
+package com.prgrms.tenwonmoa.domain.accountbook.repository;
+
+import static com.prgrms.tenwonmoa.domain.category.CategoryType.*;
+import static java.time.LocalDateTime.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.prgrms.tenwonmoa.common.fixture.RepositoryFixture;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsData;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+class StatisticsQueryRepositoryTest extends RepositoryFixture {
+	private static final String NEED_TO_YEAR_WHEN_MONTH = "월 조건은 년도가 반드시 입력되어야 합니다.";
+	public static final String NAME = "name";
+	public static final String TOTAL = "total";
+
+	private static final List<String> INCOME_DEFAULT = List.of("용돈", "상여", "금융소득");
+	private static final List<String> EXPENDITURE_DEFAULT = List.of("교통/차량", "문화생활", "마트/편의점");
+	private static final Long AMOUNT = 10L;
+
+	@Autowired
+	EntityManager em;
+	JPAQueryFactory queryFactory;
+	User user;
+
+	@Autowired
+	StatisticsQueryRepository statisticsQueryRepository;
+	UserCategory incomeUserCategory2;
+	Category incomeCategory3;
+
+	UserCategory expenditureUserCategory2;
+	Category expenditureCategory3;
+
+	@BeforeEach
+	void init() {
+		queryFactory = new JPAQueryFactory(em);
+		user = saveRandomUser();
+
+		initIncomeData();
+		initExpenditureData();
+	}
+
+	@Test
+	void 수입_월조건통계조회_성공() {
+		List<FindStatisticsData> incomes = statisticsQueryRepository
+			.searchIncomeByRegisterDate(user.getId(), 2022, 07);
+
+		assertThat(incomes).hasSize(3);
+		assertThat(incomes).extracting(NAME)
+			.containsExactly(INCOME_DEFAULT.get(0), INCOME_DEFAULT.get(1), INCOME_DEFAULT.get(2));
+		assertThat(incomes).extracting(TOTAL)
+			.containsExactly(40L, 30L, 20L);
+	}
+
+	@Test
+	void 수입_월조건통계조회_년도없으면_예외() {
+		assertThrows(IllegalArgumentException.class, () ->
+			statisticsQueryRepository.searchIncomeByRegisterDate(user.getId(), null, 07));
+	}
+
+	@Test
+	void 수입_년조건_통계_월_null_일때_성공() {
+		List<FindStatisticsData> findStatisticsData = statisticsQueryRepository.searchIncomeByRegisterDate(user.getId(),
+			2022,
+			null);
+		assertThat(findStatisticsData).hasSize(3);
+	}
+
+	@Test
+	void 유저카테고리_삭제시_카테고리의이름을_참조한다() {
+		// userCategory2 삭제
+		UserCategory findUserCategory2 = em.find(UserCategory.class, incomeUserCategory2.getId());
+		findUserCategory2.updateCategoryAsNull();
+		save(findUserCategory2);
+
+		List<FindStatisticsData> incomes = statisticsQueryRepository
+			.searchIncomeByRegisterDate(user.getId(), 2022, 07);
+		assertThat(incomes).hasSize(3);
+		assertThat(incomes).extracting(NAME)
+			.containsExactly(INCOME_DEFAULT.get(0), INCOME_DEFAULT.get(1), INCOME_DEFAULT.get(2));
+		assertThat(incomes).extracting(NAME)
+			.doesNotContainNull();
+	}
+
+	@Test
+	void 카테고리이름_변경시_변경된이름을_참조한다() {
+		// category3의 이름변경
+		Category findCategory3 = em.find(Category.class, incomeCategory3.getId());
+		String updateCategoryName = "KAN-TE";
+		findCategory3.updateName(updateCategoryName);
+		save(findCategory3);
+
+		List<FindStatisticsData> incomes = statisticsQueryRepository
+			.searchIncomeByRegisterDate(user.getId(), 2022, 07);
+		assertThat(incomes).hasSize(3);
+		assertThat(incomes).extracting(NAME)
+			.containsExactly(INCOME_DEFAULT.get(0), INCOME_DEFAULT.get(1), updateCategoryName);
+		assertThat(incomes).extracting(NAME)
+			.doesNotContain(INCOME_DEFAULT.get(2));
+	}
+
+	// 000000
+
+	@Test
+	void 지출_월조건통계조회_성공() {
+		List<FindStatisticsData> findData = statisticsQueryRepository
+			.searchExpenditureByRegisterDate(user.getId(), 2022, 07);
+
+		for (FindStatisticsData d : findData) {
+			System.out.println(d);
+		}
+		assertThat(findData).hasSize(3);
+		assertThat(findData).extracting(NAME)
+			.containsExactly(EXPENDITURE_DEFAULT.get(2), EXPENDITURE_DEFAULT.get(1), EXPENDITURE_DEFAULT.get(0));
+		assertThat(findData).extracting(TOTAL)
+			.containsExactly(30L, 20L, 10L);
+	}
+
+	@Test
+	void 지출_월조건통계조회_년도없으면_예외() {
+		assertThrows(IllegalArgumentException.class, () ->
+			statisticsQueryRepository.searchExpenditureByRegisterDate(user.getId(), null, 07));
+	}
+
+	@Test
+	void 지출_년조건_통계_월_null_일때_성공() {
+		List<FindStatisticsData> findStatisticsData = statisticsQueryRepository.searchExpenditureByRegisterDate(
+			user.getId(),
+			2022,
+			null);
+		assertThat(findStatisticsData).hasSize(3);
+	}
+
+	@Test
+	void 지출_유저카테고리_삭제시_카테고리의이름을_참조한다() {
+		// userCategory2 삭제
+		UserCategory findUserCategory2 = em.find(UserCategory.class, expenditureUserCategory2.getId());
+		findUserCategory2.updateCategoryAsNull();
+		save(findUserCategory2);
+
+		List<FindStatisticsData> findData = statisticsQueryRepository
+			.searchExpenditureByRegisterDate(user.getId(), 2022, 07);
+		assertThat(findData).hasSize(3);
+		assertThat(findData).extracting(NAME)
+			.containsExactly(EXPENDITURE_DEFAULT.get(2), EXPENDITURE_DEFAULT.get(1), EXPENDITURE_DEFAULT.get(0));
+		assertThat(findData).extracting(NAME)
+			.doesNotContainNull();
+	}
+
+	@Test
+	void 지출_카테고리이름_변경시_변경된이름을_참조한다() {
+		// category3의 이름변경
+		Category findCategory3 = em.find(Category.class, expenditureCategory3.getId());
+		String updateCategoryName = "KAN-TE";
+		findCategory3.updateName(updateCategoryName);
+		save(findCategory3);
+
+		List<FindStatisticsData> findData = statisticsQueryRepository
+			.searchExpenditureByRegisterDate(user.getId(), 2022, 07);
+		assertThat(findData).hasSize(3);
+		assertThat(findData).extracting(NAME)
+			.containsExactly(updateCategoryName, EXPENDITURE_DEFAULT.get(1), EXPENDITURE_DEFAULT.get(0));
+		assertThat(findData).extracting(NAME)
+			.doesNotContain(EXPENDITURE_DEFAULT.get(2));
+	}
+
+	private void initIncomeData() {
+		Category incomeCategory1 = save(new Category(INCOME_DEFAULT.get(0), INCOME));
+		Category incomeCategory2 = save(new Category(INCOME_DEFAULT.get(1), INCOME));
+		incomeCategory3 = save(new Category(INCOME_DEFAULT.get(2), INCOME));
+
+		UserCategory incomeUserCategory1 = saveUserCategory(user, incomeCategory1);
+		incomeUserCategory2 = saveUserCategory(user, incomeCategory2);
+		UserCategory incomeUserCategory3 = saveUserCategory(user, incomeCategory3);
+
+		// 2022.07월달에 category1으로 4건의 수입등록
+		iterateFixture(4, (i) -> saveIncome(incomeUserCategory1, AMOUNT, of(2022, 7, i, 0, 0, 0)));
+		// 2022.07월달에 category2으로 3건의 수입등록
+		iterateFixture(3, (i) -> saveIncome(incomeUserCategory2, AMOUNT, of(2022, 7, i, 0, 0, 0)));
+		// 2022.07월달에 category3으로 2건의 수입등록
+		iterateFixture(2, (i) -> saveIncome(incomeUserCategory3, AMOUNT, of(2022, 7, i, 0, 0, 0)));
+		// 2022.06월달에 category1으로 2건의 수입등록
+		iterateFixture(2, (i) -> saveIncome(incomeUserCategory1, AMOUNT, of(2022, 6, i, 0, 0, 0)));
+		// 2021.07월달에 category1으로 2건의 수입등록
+		iterateFixture(2, (i) -> saveIncome(incomeUserCategory1, AMOUNT, of(2022, 2, i, 0, 0, 0)));
+	}
+
+	private void initExpenditureData() {
+		Category expenditureCategory1 = save(new Category(EXPENDITURE_DEFAULT.get(0), EXPENDITURE));
+		Category expenditureCategory2 = save(new Category(EXPENDITURE_DEFAULT.get(1), EXPENDITURE));
+		expenditureCategory3 = save(new Category(EXPENDITURE_DEFAULT.get(2), EXPENDITURE));
+
+		UserCategory expenditureUserCategory1 = saveUserCategory(user, expenditureCategory1);
+		expenditureUserCategory2 = saveUserCategory(user, expenditureCategory2);
+		UserCategory expenditureUserCategory3 = saveUserCategory(user, expenditureCategory3);
+
+		// 2022.07월달에 category1으로 1건의 수입등록
+		iterateFixture(1, (i) -> saveExpenditure(expenditureUserCategory1, AMOUNT, of(2022, 7, i, 0, 0, 0)));
+		// 2022.07월달에 category2으로 2건의 수입등록
+		iterateFixture(2, (i) -> saveExpenditure(expenditureUserCategory2, AMOUNT, of(2022, 7, i, 0, 0, 0)));
+		// 2022.07월달에 category3으로 3건의 수입등록
+		iterateFixture(3, (i) -> saveExpenditure(expenditureUserCategory3, AMOUNT, of(2022, 7, i, 0, 0, 0)));
+		// 2022.06월달에 category1으로 2건의 수입등록
+		iterateFixture(2, (i) -> saveExpenditure(expenditureUserCategory1, AMOUNT, of(2022, 6, i, 0, 0, 0)));
+		// 2021.07월달에 category1으로 2건의 수입등록
+		iterateFixture(2, (i) -> saveExpenditure(expenditureUserCategory1, AMOUNT, of(2022, 2, i, 0, 0, 0)));
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
@@ -87,6 +87,7 @@ class StatisticsQueryRepositoryTest extends RepositoryFixture {
 		assertThat(incomes).extracting(NAME)
 			.doesNotContainNull();
 	}
+
 	@Test
 	void 카테고리이름_변경시_변경된이름을_참조한다() {
 		// given
@@ -104,6 +105,7 @@ class StatisticsQueryRepositoryTest extends RepositoryFixture {
 		assertThat(incomes).extracting(NAME)
 			.doesNotContain(INCOME_DEFAULT.get(2));
 	}
+
 	@Test
 	void 지출_월조건통계조회_성공() {
 		// when

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepositoryTest.java
@@ -187,7 +187,7 @@ class StatisticsQueryRepositoryTest extends RepositoryFixture {
 		// 2022.06월달에 category1으로 2건의 수입등록
 		iterateFixture(2, (i) -> saveIncome(incomeUserCategory1, AMOUNT, of(2022, 6, i, 0, 0, 0)));
 		// 2021.07월달에 category1으로 2건의 수입등록
-		iterateFixture(2, (i) -> saveIncome(incomeUserCategory1, AMOUNT, of(2022, 2, i, 0, 0, 0)));
+		iterateFixture(2, (i) -> saveIncome(incomeUserCategory1, AMOUNT, of(2021, 7, i, 0, 0, 0)));
 	}
 
 	private void initExpenditureData() {
@@ -208,6 +208,6 @@ class StatisticsQueryRepositoryTest extends RepositoryFixture {
 		// 2022.06월달에 category1으로 2건의 지출등록
 		iterateFixture(2, (i) -> saveExpenditure(expenditureUserCategory1, AMOUNT, of(2022, 6, i, 0, 0, 0)));
 		// 2021.07월달에 category1으로 2건의 지출등록
-		iterateFixture(2, (i) -> saveExpenditure(expenditureUserCategory1, AMOUNT, of(2022, 2, i, 0, 0, 0)));
+		iterateFixture(2, (i) -> saveExpenditure(expenditureUserCategory1, AMOUNT, of(2021, 7, i, 0, 0, 0)));
 	}
 }


### PR DESCRIPTION
## 개요

- 통계 페이지를 위한 쿼리구현

## 추가기능

- 통계 페이지를 위한 QueryDSL 쿼리구현
- 하나의 쿼리로 연별 조회, 월별 조회 모두 처리되고 있습니다.

## 사용방법(Optional)
- ` statistics/year={year} `와 `statistics/year={year}&month={month}` 요청에 필요한 데이터를 조회한다.
- 추가 된 `searchIncomeByRegisterDate`와 `searchExpenditureByRegisterDate` 함수는 동일한 조건으로 데이터를 조회합니다. Entity가 구분되어있어 각각 조회할 수 있도록 분리해서 구현했습니다.
  

## 기타
- 아래 incomes와, expenditures를 조회하기 위한 쿼리입니다.
- percent는 service에서 풀 예정입니다.

![image](https://user-images.githubusercontent.com/26343023/183122946-e9bdd65d-2d24-4d78-b52c-97c1c4d9adcd.png)

- 실제 수행되는 쿼리는 아래와 같습니다.
``` sql

   select
        coalesce(category2_.name,
        income0_.category_name) as col_0_0_,
        sum(income0_.amount) as col_1_0_ 
    from
        income income0_ 
    left outer join
        user_category usercatego1_ 
            on income0_.user_category_id=usercatego1_.id 
    left outer join
        category category2_ 
            on usercatego1_.category_id=category2_.id 
    where
        year(income0_.register_date)=? 
        and month(income0_.register_date)=? 
        and income0_.user_id=? 
    group by
        col_0_0_ 
    order by
        col_1_0_ desc

```
