### PR TITLE
[#136] 검색 API 컨트롤러 구현 & 테스트

### DIFF
--- a/docs/search-account-book.adoc
+++ b/docs/search-account-book.adoc
@@ -1,0 +1,5 @@
+== 검색
+
+=== 지출, 수입 검색
+
+operation::search-account-book/[snippets='http-request,request-parameters,http-response,response-fields']

--- a/docs/user-category.adoc
+++ b/docs/user-category.adoc
@@ -2,16 +2,16 @@
 
 === 카테고리 등록
 
-operation::user-category-controller-test/카테고리_등록[snippets='http-request,request-fields,http-response,response-fields']
+operation::user-category-controller-unit-test/카테고리_등록[snippets='http-request,request-fields,http-response,response-fields']
 
 === 카테고리 조회
 
-operation::user-category-controller-test/카테고리_조회[snippets='http-request,request-parameters,http-response,response-fields']
+operation::user-category-controller-unit-test/카테고리_조회[snippets='http-request,request-parameters,http-response,response-fields']
 
 === 카테고리 수정
 
-operation::user-category-controller-test/카테고리_수정[snippets='http-request,request-fields,http-response,response-fields']
+operation::user-category-controller-unit-test/카테고리_수정[snippets='http-request,request-fields,http-response,response-fields']
 
 === 카테고리 삭제
 
-operation::user-category-controller-test/카테고리_삭제[snippets='http-request,path-parameters,http-response']
+operation::user-category-controller-unit-test/카테고리_삭제[snippets='http-request,path-parameters,http-response']

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
@@ -47,7 +47,6 @@ public class SearchAccountBookController {
 
 		FindAccountBookResponse response = accountBookService.searchAccountBooks(userId,
 			SearchAccountBookCmd.of(categories, minPrice, maxPrice, start, end, content), pageRequest);
-		response.setPageInfo(pageRequest);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
@@ -1,10 +1,10 @@
 package com.prgrms.tenwonmoa.domain.accountbook.controller;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,8 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.SearchAccountBookResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookCmd;
 import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookService;
-import com.prgrms.tenwonmoa.domain.category.CategoryType;
-import com.prgrms.tenwonmoa.domain.category.dto.FindCategoryResponse;
 import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
 
@@ -37,32 +35,27 @@ public class SearchAccountBookController {
 		@RequestParam(defaultValue = "") String categories,
 		@RequestParam(name = "minprice", required = false) Long minPrice,
 		@RequestParam(name = "maxprice", required = false) Long maxPrice,
-		@RequestParam(required = false) LocalDate start,
-		@RequestParam(required = false) LocalDate end,
+		@RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
+		@RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end,
 		@RequestParam(defaultValue = "") String content,
 		@RequestParam(defaultValue = "10") int size,
 		@RequestParam(defaultValue = "1") int page) {
 
 		categories = categories.isEmpty() ? getAllCategories(userId) : categories;
 
+		PageCustomRequest pageRequest = new PageCustomRequest(page, size);
+
 		SearchAccountBookResponse response = accountBookService.searchAccountBooks(userId,
-			SearchAccountBookCmd.of(categories, minPrice, maxPrice, start, end, content),
-			new PageCustomRequest(page, size));
+			SearchAccountBookCmd.of(categories, minPrice, maxPrice, start, end, content), pageRequest);
+		response.setPageInfo(pageRequest);
 
 		return ResponseEntity.ok(response);
 	}
 
 	private String getAllCategories(Long userId) {
-		FindCategoryResponse expenditureCategories = userCategoryService.findUserCategories(userId,
-			CategoryType.EXPENDITURE.name());
-		FindCategoryResponse incomeCategories = userCategoryService.findUserCategories(userId,
-			CategoryType.INCOME.name());
+		List<Long> allUserCategories = userCategoryService.findAllUserCategoryIds(userId);
 
-		List<Long> categoryIds = new ArrayList<>();
-		expenditureCategories.getCategories().forEach(resp -> categoryIds.add(resp.getId()));
-		incomeCategories.getCategories().forEach(resp -> categoryIds.add(resp.getId()));
-
-		return String.join(",", categoryIds.stream()
+		return String.join(",", allUserCategories.stream()
 			.map(String::valueOf)
 			.collect(Collectors.toList())
 			.toArray(String[]::new));

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/account-book")
 public class SearchAccountBookController {
 
+	private static final String CATEGORY_DELIMITER = ",";
 	private final SearchAccountBookService accountBookService;
 
 	private final FindUserCategoryService userCategoryService;
@@ -54,7 +55,7 @@ public class SearchAccountBookController {
 	private String getAllCategories(Long userId) {
 		List<Long> allUserCategories = userCategoryService.findAllUserCategoryIds(userId);
 
-		return String.join(",", allUserCategories.stream()
+		return String.join(CATEGORY_DELIMITER, allUserCategories.stream()
 			.map(String::valueOf)
 			.collect(Collectors.toList())
 			.toArray(String[]::new));

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
@@ -1,0 +1,70 @@
+package com.prgrms.tenwonmoa.domain.accountbook.controller;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prgrms.tenwonmoa.domain.accountbook.dto.SearchAccountBookResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookCmd;
+import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookService;
+import com.prgrms.tenwonmoa.domain.category.CategoryType;
+import com.prgrms.tenwonmoa.domain.category.dto.FindCategoryResponse;
+import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
+import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/account-book")
+public class SearchAccountBookController {
+
+	private final SearchAccountBookService accountBookService;
+
+	private final FindUserCategoryService userCategoryService;
+
+	@GetMapping("/search")
+	public ResponseEntity<SearchAccountBookResponse> searchAccountBooks(
+		@AuthenticationPrincipal Long userId,
+		@RequestParam(defaultValue = "") String categories,
+		@RequestParam(name = "minprice", required = false) Long minPrice,
+		@RequestParam(name = "maxprice", required = false) Long maxPrice,
+		@RequestParam(required = false) LocalDate start,
+		@RequestParam(required = false) LocalDate end,
+		@RequestParam(defaultValue = "") String content,
+		@RequestParam(defaultValue = "10") int size,
+		@RequestParam(defaultValue = "1") int page) {
+
+		categories = categories.isEmpty() ? getAllCategories(userId) : categories;
+
+		SearchAccountBookResponse response = accountBookService.searchAccountBooks(userId,
+			SearchAccountBookCmd.of(categories, minPrice, maxPrice, start, end, content),
+			new PageCustomRequest(page, size));
+
+		return ResponseEntity.ok(response);
+	}
+
+	private String getAllCategories(Long userId) {
+		FindCategoryResponse expenditureCategories = userCategoryService.findUserCategories(userId,
+			CategoryType.EXPENDITURE.name());
+		FindCategoryResponse incomeCategories = userCategoryService.findUserCategories(userId,
+			CategoryType.INCOME.name());
+
+		List<Long> categoryIds = new ArrayList<>();
+		expenditureCategories.getCategories().forEach(resp -> categoryIds.add(resp.getId()));
+		incomeCategories.getCategories().forEach(resp -> categoryIds.add(resp.getId()));
+
+		return String.join(",", categoryIds.stream()
+			.map(String::valueOf)
+			.collect(Collectors.toList())
+			.toArray(String[]::new));
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.prgrms.tenwonmoa.domain.accountbook.dto.SearchAccountBookResponse;
-import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookCmd;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.service.SearchAccountBookCmd;
 import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookService;
 import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
@@ -30,7 +30,7 @@ public class SearchAccountBookController {
 	private final FindUserCategoryService userCategoryService;
 
 	@GetMapping("/search")
-	public ResponseEntity<SearchAccountBookResponse> searchAccountBooks(
+	public ResponseEntity<FindAccountBookResponse> searchAccountBooks(
 		@AuthenticationPrincipal Long userId,
 		@RequestParam(defaultValue = "") String categories,
 		@RequestParam(name = "minprice", required = false) Long minPrice,
@@ -45,7 +45,7 @@ public class SearchAccountBookController {
 
 		PageCustomRequest pageRequest = new PageCustomRequest(page, size);
 
-		SearchAccountBookResponse response = accountBookService.searchAccountBooks(userId,
+		FindAccountBookResponse response = accountBookService.searchAccountBooks(userId,
 			SearchAccountBookCmd.of(categories, minPrice, maxPrice, start, end, content), pageRequest);
 		response.setPageInfo(pageRequest);
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindAccountBookResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindAccountBookResponse.java
@@ -3,38 +3,29 @@ package com.prgrms.tenwonmoa.domain.accountbook.dto;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public final class FindAccountBookResponse {
-
-	private final List<Result> results;
+public final class FindAccountBookResponse extends PageCustomImpl<FindAccountBookResponse.Result> {
 
 	private final Long incomeSum;
 
 	private final Long expenditureSum;
 
-	private Integer currentPage;
-
-	private Integer nextPage;
-
-	public static FindAccountBookResponse of(List<Result> results, Long incomeSum, Long expenditureSum) {
-		return new FindAccountBookResponse(results, incomeSum, expenditureSum);
+	private FindAccountBookResponse(PageCustomRequest pageRequest, List<FindAccountBookResponse.Result> results,
+		Long incomeSum, Long expenditureSum) {
+		super(pageRequest, results);
+		this.expenditureSum = expenditureSum;
+		this.incomeSum = incomeSum;
 	}
 
-	public void setPageInfo(PageCustomRequest pageRequest) {
-		this.currentPage = pageRequest.getPage();
-		this.nextPage = this.currentPage + 1;
-
-		// 마지막 페이지일 경우
-		if (this.results.size() < pageRequest.getSize()) {
-			nextPage = null;
-		}
+	public static FindAccountBookResponse of(PageCustomRequest pageRequest,
+		List<FindAccountBookResponse.Result> results, Long incomeSum, Long expenditureSum) {
+		return new FindAccountBookResponse(pageRequest, results, incomeSum, expenditureSum);
 	}
 
 	@Getter

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/SearchAccountBookResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/SearchAccountBookResponse.java
@@ -3,6 +3,8 @@ package com.prgrms.tenwonmoa.domain.accountbook.dto;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,8 +18,22 @@ public final class SearchAccountBookResponse {
 
 	private final Long expenditureSum;
 
+	private Integer currentPage;
+
+	private Integer nextPage;
+
 	public static SearchAccountBookResponse of(List<Result> results, Long incomeSum, Long expenditureSum) {
 		return new SearchAccountBookResponse(results, incomeSum, expenditureSum);
+	}
+
+	public void setPageInfo(PageCustomRequest pageRequest) {
+		this.currentPage = pageRequest.getPage();
+		this.nextPage = this.currentPage + 1;
+
+		// 마지막 페이지일 경우
+		if (this.results.size() < pageRequest.getSize()) {
+			nextPage = null;
+		}
 	}
 
 	@Getter

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/service/SearchAccountBookCmd.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/service/SearchAccountBookCmd.java
@@ -29,7 +29,7 @@ public final class SearchAccountBookCmd {
 	public static SearchAccountBookCmd of(String categoryString, Long minPrice, Long maxPrice, LocalDate start,
 		LocalDate end, String content) {
 		String[] categoryIds = categoryString.split(",");
-		List<Long> categories = Arrays.stream(categoryIds).map(Long::getLong).collect(Collectors.toList());
+		List<Long> categories = Arrays.stream(categoryIds).map(Long::valueOf).collect(Collectors.toList());
 
 		minPrice = minPrice == null ? AccountBookConst.AMOUNT_MIN : minPrice;
 		maxPrice = maxPrice == null ? AccountBookConst.AMOUNT_MAX : maxPrice;

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
@@ -73,7 +73,7 @@ public class SearchAccountBookService {
 			}
 		}
 
-		return FindAccountBookResponse.of(slicedResult, incomeSum, expenditureSum);
+		return FindAccountBookResponse.of(pageRequest, slicedResult, incomeSum, expenditureSum);
 	}
 
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
@@ -1,5 +1,6 @@
 package com.prgrms.tenwonmoa.domain.accountbook.service;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,12 +54,19 @@ public class SearchAccountBookService {
 	}
 
 	private FindAccountBookResponse sliceAndSum(List<Result> results, PageCustomRequest pageRequest) {
-		List<Result> slicedResult = results.subList(0, pageRequest.getSize());
+		List<Result> slicedResult;
+
+		if (results.size() > pageRequest.getSize()) {
+			slicedResult = new ArrayList<>(results.subList(0, pageRequest.getSize()));
+		} else {
+			slicedResult = new ArrayList<>(results);
+		}
+
 		Long incomeSum = 0L;
 		Long expenditureSum = 0L;
 
 		for (Result result : slicedResult) {
-			if (result.getType().equals(CategoryType.EXPENDITURE.name())) {
+			if (result.getType().equals(CategoryType.INCOME.name())) {
 				incomeSum += result.getAmount();
 			} else {
 				expenditureSum += result.getAmount();

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/UserCategory.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/UserCategory.java
@@ -42,8 +42,8 @@ public class UserCategory extends BaseEntity {
 		return this.category.getName();
 	}
 
-	public CategoryType getCategoryType() {
-		return this.category.getCategoryType();
+	public String getCategoryTypeName() {
+		return this.category.getCategoryType().name();
 	}
 
 	public void updateCategoryAsNull() {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/dto/FindCategoryResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/dto/FindCategoryResponse.java
@@ -19,7 +19,7 @@ public final class FindCategoryResponse {
 		List<SingleCategoryResponse> categoryResults = categories.stream()
 			.map(userCategory -> new SingleCategoryResponse(
 				userCategory.getId(), userCategory.getCategoryName(),
-				userCategory.getCategoryType().name()))
+				userCategory.getCategoryTypeName()))
 			.collect(Collectors.toList());
 
 		return new FindCategoryResponse(categoryResults);

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepository.java
@@ -17,4 +17,6 @@ public interface UserCategoryRepository extends JpaRepository<UserCategory, Long
 		+ "where uc.user.id = :userId "
 		+ "and c.categoryType = :categoryType")
 	List<UserCategory> findByUserIdAndCategoryType(Long userId, CategoryType categoryType);
+
+	List<UserCategory> findByUserId(Long userId);
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/service/FindUserCategoryService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/service/FindUserCategoryService.java
@@ -2,6 +2,7 @@ package com.prgrms.tenwonmoa.domain.category.service;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,5 +27,10 @@ public class FindUserCategoryService {
 		List<UserCategory> userCategories = repository.findByUserIdAndCategoryType(userId, type);
 
 		return FindCategoryResponse.of(userCategories);
+	}
+
+	public List<Long> findAllUserCategoryIds(Long userId) {
+		List<UserCategory> userCategories = repository.findByUserId(userId);
+		return userCategories.stream().map(UserCategory::getId).collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/service/TokenProvider.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/service/TokenProvider.java
@@ -25,7 +25,7 @@ public class TokenProvider {
 		builder.withIssuer(jwt.getIssuer());
 		builder.withIssuedAt(now);
 		if (jwt.getExpirySeconds() > 0) {
-			builder.withExpiresAt(new Date(now.getTime() + jwt.getExpirySeconds()));
+			builder.withExpiresAt(new Date(now.getTime() + jwt.getExpirySeconds() * 1000L));
 		}
 		builder.withClaim("userId", userId)
 			.withClaim("email", email);

--- a/src/test/java/com/prgrms/tenwonmoa/common/BaseControllerIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/BaseControllerIntegrationTest.java
@@ -3,9 +3,12 @@ package com.prgrms.tenwonmoa.common;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
@@ -13,6 +16,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.income.CreateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.category.dto.CreateCategoryRequest;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -57,5 +62,53 @@ public class BaseControllerIntegrationTest {
 
 		JsonNode responseJson = objectMapper.readTree(responseBody);
 		accessToken = "Bearer " + responseJson.get("accessToken").asText();
+	}
+
+	protected void 지출_등록(Long userCategoryId, Long amount,
+		String content, LocalDateTime registerDate) throws Exception {
+
+		ObjectNode objectNode = objectMapper.createObjectNode();
+		objectNode.put("registerDate", registerDate.toString());
+		objectNode.put("amount", amount)
+			.put("content", content)
+			.put("userCategoryId", userCategoryId);
+
+		mvc.perform(post("/api/v1/expenditures")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectNode.toString())
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("id").exists());
+	}
+
+	protected void 수입_등록(Long userCategoryId, Long amount,
+		String content, LocalDateTime registerDate) throws Exception {
+		CreateIncomeRequest request = new CreateIncomeRequest(registerDate, amount, content,
+			userCategoryId);
+
+		mvc.perform(post("/api/v1/incomes").contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("id").exists());
+	}
+
+	protected Long 카테고리_등록(String categoryType, String categoryName) throws Exception {
+		//given
+		CreateCategoryRequest createCategoryRequest
+			= new CreateCategoryRequest(categoryType, categoryName);
+
+		//when
+		//then
+		String response = mvc.perform(post("/api/v1/categories")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createCategoryRequest))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpectAll(
+				status().isCreated(),
+				jsonPath("$.id").exists()
+			)
+			.andReturn().getResponse().getContentAsString();
+		return objectMapper.readTree(response).get("id").asLong();
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookControllerTest.java
@@ -1,7 +1,7 @@
 package com.prgrms.tenwonmoa.domain.accountbook.controller;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
-import static com.prgrms.tenwonmoa.domain.accountbook.dto.SearchAccountBookResponse.*;
+import static com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -28,8 +28,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
 import com.prgrms.tenwonmoa.config.JwtConfigure;
 import com.prgrms.tenwonmoa.config.WebSecurityConfig;
-import com.prgrms.tenwonmoa.domain.accountbook.dto.SearchAccountBookResponse;
-import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookCmd;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.service.SearchAccountBookCmd;
 import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookService;
 import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
@@ -60,7 +60,7 @@ class SearchAccountBookControllerTest {
 	@Test
 	@WithMockCustomUser
 	void 지출_수입_검색() throws Exception {
-		SearchAccountBookResponse response = of(
+		FindAccountBookResponse response = of(
 			List.of(
 				new Result(LocalDate.now(), 10000L, "점심", 1L, "EXPENDITURE", "식비"),
 				new Result(LocalDate.now(), 50000L, "용돈", 1L, "INCOME", "용돈")),

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookControllerTest.java
@@ -61,7 +61,9 @@ class SearchAccountBookControllerTest {
 	@Test
 	@WithMockCustomUser
 	void 지출_수입_검색() throws Exception {
+		PageCustomRequest pageRequest = new PageCustomRequest(1, 1);
 		FindAccountBookResponse response = of(
+			pageRequest,
 			List.of(
 				new Result(LocalDate.now(), 10000L, "점심", 1L, "EXPENDITURE", "식비"),
 				new Result(LocalDate.now(), 50000L, "용돈", 1L, "INCOME", "용돈")),
@@ -77,8 +79,8 @@ class SearchAccountBookControllerTest {
 				.param("start", "2022-08-01")
 				.param("end", "2022-08-10")
 				.param("content", "점심")
-				.param("size", "1")
-				.param("page", "1"))
+				.param("size", String.valueOf(pageRequest.getSize()))
+				.param("page", String.valueOf(pageRequest.getPage())))
 			.andExpect(status().isOk())
 			.andDo(
 				document("search-account-book",

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookControllerTest.java
@@ -1,0 +1,110 @@
+package com.prgrms.tenwonmoa.domain.accountbook.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.prgrms.tenwonmoa.domain.accountbook.dto.SearchAccountBookResponse.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
+import com.prgrms.tenwonmoa.config.JwtConfigure;
+import com.prgrms.tenwonmoa.config.WebSecurityConfig;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.SearchAccountBookResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookCmd;
+import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookService;
+import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
+import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
+
+@WebMvcTest(controllers = SearchAccountBookController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtConfigure.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+	}
+)
+@MockBean(JpaMetamodelMappingContext.class)
+@DisplayName("가계부 검색 컨트롤러 테스트")
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+class SearchAccountBookControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private SearchAccountBookService accountBookService;
+
+	@MockBean
+	private FindUserCategoryService userCategoryService;
+
+	@Test
+	@WithMockCustomUser
+	void 지출_수입_검색() throws Exception {
+		SearchAccountBookResponse response = of(
+			List.of(
+				new Result(LocalDate.now(), 10000L, "점심", 1L, "EXPENDITURE", "식비"),
+				new Result(LocalDate.now(), 50000L, "용돈", 1L, "INCOME", "용돈")),
+			50000L, 10000L);
+
+		given(accountBookService.searchAccountBooks(anyLong(), any(SearchAccountBookCmd.class), any(
+			PageCustomRequest.class))).willReturn(response);
+
+		mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/account-book/search")
+				.param("categories", "1,2,3")
+				.param("minprice", "1000")
+				.param("maxprice", "50000")
+				.param("start", "2022-08-01")
+				.param("end", "2022-08-10")
+				.param("content", "점심")
+				.param("size", "1")
+				.param("page", "1"))
+			.andExpect(status().isOk())
+			.andDo(
+				document("search-account-book",
+					requestParameters(
+						parameterWithName("categories").description("유저카테고리 아이디"),
+						parameterWithName("minprice").description("최소 가격"),
+						parameterWithName("maxprice").description("최대 가격"),
+						parameterWithName("start").description("시작 등록일"),
+						parameterWithName("end").description("종료 등록일"),
+						parameterWithName("content").description("지출, 수입의 내용"),
+						parameterWithName("size").description("페이지의 사이즈"),
+						parameterWithName("page").description("페이지 번호")
+					),
+					responseFields(
+						fieldWithPath("incomeSum").type(JsonFieldType.NUMBER).description("수입의 총합"),
+						fieldWithPath("expenditureSum").type(JsonFieldType.NUMBER).description("지출의 총합"),
+						fieldWithPath("currentPage").type(JsonFieldType.NUMBER).description("현재 페이지"),
+						fieldWithPath("nextPage").type(JsonFieldType.NUMBER).description("다음 페이지"),
+						fieldWithPath("results[]").type(JsonFieldType.ARRAY).description("검색된 지출, 수입 데이터"),
+						fieldWithPath("results[].registerDate").type(JsonFieldType.STRING).description("등록일"),
+						fieldWithPath("results[].amount").type(JsonFieldType.NUMBER).description("금액"),
+						fieldWithPath("results[].content").type(JsonFieldType.STRING).description("내용"),
+						fieldWithPath("results[].id").type(JsonFieldType.NUMBER).description("지출 or 수입의 아이디"),
+						fieldWithPath("results[].type").type(JsonFieldType.STRING).description("지출 or 수입 종류"),
+						fieldWithPath("results[].categoryName").type(JsonFieldType.STRING).description("카테고리 이름")
+					)
+				)
+			);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -81,6 +82,8 @@ class SearchAccountBookControllerTest {
 			.andExpect(status().isOk())
 			.andDo(
 				document("search-account-book",
+					Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+					Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
 					requestParameters(
 						parameterWithName("categories").description("유저카테고리 아이디"),
 						parameterWithName("minprice").description("최소 가격"),

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookIntegrationTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -38,7 +37,7 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 		지출_등록(expenditureCategoryId, 5000L, "점심", LocalDateTime.now());
 
 		String categories = String.join(",", String.valueOf(incomeCategoryId), String.valueOf(expenditureCategoryId));
-		mvc.perform(MockMvcRequestBuilders.get("/api/v1/account-book/search")
+		mvc.perform(get("/api/v1/account-book/search")
 				.header(HttpHeaders.AUTHORIZATION, accessToken)
 				.param("categories", categories)
 				.param("minprice", "0")
@@ -64,7 +63,7 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 		지출_등록(expenditureCategoryId, 5000L, "점심", LocalDateTime.now());
 
 		String blankCategory = "";
-		mvc.perform(MockMvcRequestBuilders.get("/api/v1/account-book/search")
+		mvc.perform(get("/api/v1/account-book/search")
 				.header(HttpHeaders.AUTHORIZATION, accessToken)
 				.param("categories", blankCategory)
 				.param("minprice", "0")
@@ -78,9 +77,7 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 			.andExpect(jsonPath("$.expenditureSum").value(5000L))
 			.andExpect(jsonPath("$.currentPage").value(1))
 			.andExpect(jsonPath("$.nextPage").isEmpty())
-			.andExpect(jsonPath("$.results", hasSize(2))
-			);
-
+			.andExpect(jsonPath("$.results", hasSize(2)));
 	}
 
 	private void 지출_등록(Long userCategoryId, Long amount,

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookIntegrationTest.java
@@ -1,0 +1,106 @@
+package com.prgrms.tenwonmoa.domain.accountbook.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.prgrms.tenwonmoa.common.BaseControllerIntegrationTest;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.income.CreateIncomeRequest;
+import com.prgrms.tenwonmoa.domain.category.dto.CreateCategoryRequest;
+
+@DisplayName("검색 컨트롤러 통합 테스트")
+@Transactional
+class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
+
+	@BeforeEach
+	void setup() throws Exception {
+		registerUserAndLogin();
+	}
+
+	@Test
+	void 검색_Api() throws Exception {
+		Long incomeCategoryId = 카테고리_등록("INCOME", "월급");
+		Long expenditureCategoryId = 카테고리_등록("EXPENDITURE", "식비");
+		수입_등록(incomeCategoryId, 10000L, "용돈", LocalDateTime.now());
+		지출_등록(expenditureCategoryId, 5000L, "점심", LocalDateTime.now());
+
+		String categories = String.join(",", String.valueOf(incomeCategoryId), String.valueOf(expenditureCategoryId));
+		mvc.perform(MockMvcRequestBuilders.get("/api/v1/account-book/search")
+				.header(HttpHeaders.AUTHORIZATION, accessToken)
+				.param("categories", categories)
+				.param("minprice", "0")
+				.param("maxprice", "10000")
+				.param("start", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+				.param("end", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+				.param("content", "")
+				.param("size", "3")
+				.param("page", "1"))
+			.andExpect(jsonPath("$.incomeSum").value(10000L))
+			.andExpect(jsonPath("$.expenditureSum").value(5000L))
+			.andExpect(jsonPath("$.currentPage").value(1))
+			.andExpect(jsonPath("$.nextPage").isEmpty())
+			.andExpect(jsonPath("$.results", hasSize(2))
+			);
+	}
+
+	private void 지출_등록(Long userCategoryId, Long amount,
+		String content, LocalDateTime registerDate) throws Exception {
+
+		ObjectNode objectNode = objectMapper.createObjectNode();
+		objectNode.put("registerDate", registerDate.toString());
+		objectNode.put("amount", amount)
+			.put("content", content)
+			.put("userCategoryId", userCategoryId);
+
+		mvc.perform(post("/api/v1/expenditures")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectNode.toString())
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("id").exists());
+	}
+
+	private void 수입_등록(Long userCategoryId, Long amount,
+		String content, LocalDateTime registerDate) throws Exception {
+		CreateIncomeRequest request = new CreateIncomeRequest(registerDate, amount, content,
+			userCategoryId);
+
+		mvc.perform(post("/api/v1/incomes").contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("id").exists());
+	}
+
+	private Long 카테고리_등록(String categoryType, String categoryName) throws Exception {
+		//given
+		CreateCategoryRequest createCategoryRequest
+			= new CreateCategoryRequest(categoryType, categoryName);
+
+		//when
+		//then
+		String response = mvc.perform(post("/api/v1/categories")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createCategoryRequest))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpectAll(
+				status().isCreated(),
+				jsonPath("$.id").exists()
+			)
+			.andReturn().getResponse().getContentAsString();
+		return objectMapper.readTree(response).get("id").asLong();
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookIntegrationTest.java
@@ -42,6 +42,32 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 				.header(HttpHeaders.AUTHORIZATION, accessToken)
 				.param("categories", categories)
 				.param("minprice", "0")
+				.param("maxprice", "5000")
+				.param("start", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+				.param("end", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+				.param("content", "")
+				.param("size", "3")
+				.param("page", "1"))
+			.andExpect(jsonPath("$.incomeSum").value(0L))
+			.andExpect(jsonPath("$.expenditureSum").value(5000L))
+			.andExpect(jsonPath("$.currentPage").value(1))
+			.andExpect(jsonPath("$.nextPage").isEmpty())
+			.andExpect(jsonPath("$.results", hasSize(1))
+			);
+	}
+
+	@Test
+	void 검색_Api_모든_카테고리로_조회() throws Exception {
+		Long incomeCategoryId = 카테고리_등록("INCOME", "월급");
+		Long expenditureCategoryId = 카테고리_등록("EXPENDITURE", "식비");
+		수입_등록(incomeCategoryId, 10000L, "용돈", LocalDateTime.now());
+		지출_등록(expenditureCategoryId, 5000L, "점심", LocalDateTime.now());
+
+		String blankCategory = "";
+		mvc.perform(MockMvcRequestBuilders.get("/api/v1/account-book/search")
+				.header(HttpHeaders.AUTHORIZATION, accessToken)
+				.param("categories", blankCategory)
+				.param("minprice", "0")
 				.param("maxprice", "10000")
 				.param("start", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
 				.param("end", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
@@ -54,6 +80,7 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 			.andExpect(jsonPath("$.nextPage").isEmpty())
 			.andExpect(jsonPath("$.results", hasSize(2))
 			);
+
 	}
 
 	private void 지출_등록(Long userCategoryId, Long amount,

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookIntegrationTest.java
@@ -12,13 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.prgrms.tenwonmoa.common.BaseControllerIntegrationTest;
-import com.prgrms.tenwonmoa.domain.accountbook.dto.income.CreateIncomeRequest;
-import com.prgrms.tenwonmoa.domain.category.dto.CreateCategoryRequest;
 
 @DisplayName("검색 컨트롤러 통합 테스트")
 @Transactional
@@ -80,51 +76,19 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 			.andExpect(jsonPath("$.results", hasSize(2)));
 	}
 
-	private void 지출_등록(Long userCategoryId, Long amount,
-		String content, LocalDateTime registerDate) throws Exception {
+	@Test
+	void 검색_Api_디폴트_조회() throws Exception {
+		Long incomeCategoryId = 카테고리_등록("INCOME", "월급");
+		Long expenditureCategoryId = 카테고리_등록("EXPENDITURE", "식비");
+		수입_등록(incomeCategoryId, 10000L, "용돈", LocalDateTime.now());
+		지출_등록(expenditureCategoryId, 5000L, "점심", LocalDateTime.now());
 
-		ObjectNode objectNode = objectMapper.createObjectNode();
-		objectNode.put("registerDate", registerDate.toString());
-		objectNode.put("amount", amount)
-			.put("content", content)
-			.put("userCategoryId", userCategoryId);
-
-		mvc.perform(post("/api/v1/expenditures")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectNode.toString())
+		mvc.perform(get("/api/v1/account-book/search")
 				.header(HttpHeaders.AUTHORIZATION, accessToken))
-			.andExpect(status().isCreated())
-			.andExpect(jsonPath("id").exists());
-	}
-
-	private void 수입_등록(Long userCategoryId, Long amount,
-		String content, LocalDateTime registerDate) throws Exception {
-		CreateIncomeRequest request = new CreateIncomeRequest(registerDate, amount, content,
-			userCategoryId);
-
-		mvc.perform(post("/api/v1/incomes").contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request))
-				.header(HttpHeaders.AUTHORIZATION, accessToken))
-			.andExpect(status().isCreated())
-			.andExpect(jsonPath("id").exists());
-	}
-
-	private Long 카테고리_등록(String categoryType, String categoryName) throws Exception {
-		//given
-		CreateCategoryRequest createCategoryRequest
-			= new CreateCategoryRequest(categoryType, categoryName);
-
-		//when
-		//then
-		String response = mvc.perform(post("/api/v1/categories")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(createCategoryRequest))
-				.header(HttpHeaders.AUTHORIZATION, accessToken))
-			.andExpectAll(
-				status().isCreated(),
-				jsonPath("$.id").exists()
-			)
-			.andReturn().getResponse().getContentAsString();
-		return objectMapper.readTree(response).get("id").asLong();
+			.andExpect(jsonPath("$.incomeSum").value(10000L))
+			.andExpect(jsonPath("$.expenditureSum").value(5000L))
+			.andExpect(jsonPath("$.currentPage").value(1))
+			.andExpect(jsonPath("$.nextPage").isEmpty())
+			.andExpect(jsonPath("$.results", hasSize(2)));
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/UserCategoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/UserCategoryTest.java
@@ -56,7 +56,7 @@ class UserCategoryTest {
 
 		//when
 		//then
-		assertThat(userCategory.getCategoryType()).isEqualTo(CategoryType.EXPENDITURE);
+		assertThat(userCategory.getCategoryTypeName()).isEqualTo(CategoryType.EXPENDITURE.name());
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepositoryTest.java
@@ -56,6 +56,6 @@ class UserCategoryRepositoryTest extends RepositoryTest {
 		// then
 		assertThat(allUserCategories).hasSize(3);
 		assertThat(expenditureCategories).hasSize(1);
-		assertThat(expenditureCategories.get(0).getCategoryType()).isEqualTo(CategoryType.EXPENDITURE);
+		assertThat(expenditureCategories.get(0).getCategoryTypeName()).isEqualTo(CategoryType.EXPENDITURE.name());
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/category/service/FindUserCategoryServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/category/service/FindUserCategoryServiceTest.java
@@ -3,6 +3,8 @@ package com.prgrms.tenwonmoa.domain.category.service;
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -89,5 +91,26 @@ class FindUserCategoryServiceTest {
 		assertThatIllegalArgumentException().isThrownBy(
 			() -> findUserCategoryService.findUserCategories(user.getId(), "NOT_VALID")
 		);
+	}
+
+	@Test
+	void 유저_아이디로_모든_유저카테고리_아이디_조회() {
+		//given
+		Long id1 = userCategoryService.createUserCategory(user, "EXPENDITURE", "식비");
+		Long id2 = userCategoryService.createUserCategory(user, "EXPENDITURE", "교통비");
+		Long id3 = userCategoryService.createUserCategory(user, "EXPENDITURE", "문화생활");
+		Long id4 = userCategoryService.createUserCategory(user, "INCOME", "월급");
+		Long id5 = userCategoryService.createUserCategory(user, "INCOME", "투자");
+
+		// 일부 유저카테고리의 카테고리 null 만듦
+		userCategoryService.deleteUserCategory(user, id3);
+		userCategoryService.deleteUserCategory(user, id5);
+
+		//when
+		List<Long> allUserCategories =
+			findUserCategoryService.findAllUserCategoryIds(user.getId());
+
+		//then
+		assertThat(allUserCategories).containsExactlyInAnyOrder(id1, id2, id3, id4, id5);
 	}
 }


### PR DESCRIPTION
## 개요

- 검색 API 컨트롤러 구현

## 추가기능
- userId로 모든 카테고리 가져오는 메서드
`FindUserCategoryService`의 `public List<Long> findAllUserCategoryIds(Long userId)`
- /search api 구현  & 통합, 단위 테스트 작성
 `SearchAccountBookController`, `ResponseEntity<FindAccountBookResponse> searchAccountBooks`
   - 쿼리 파라미터
   - 카테고리
   - 최소금액
   - 최대금액
   - 시작일
   - 종료일
   - 내용
   - 페이지 사이즈
   - 페이지 번호
<img width="252" alt="image" src="https://user-images.githubusercontent.com/78348340/183253013-3a435879-14db-47f1-8485-5bdd70b308fd.png"> <img width="240" alt="image" src="https://user-images.githubusercontent.com/78348340/183253040-51ef93c6-6ca5-45c0-a3af-9be6638223fd.png">
- adoc 파일 추가

## 변경사항(Optional)

- Jwt 토큰 만료시간 계산 로직에서 Date안에서 더하는건 millisec 단위라 1000L을 곱해줘야 해서 곱해주었습니다
- UserCategory의 getCategoryName() 메서드 시그니처 변경
`public CategoryType getCategoryTypeName()` -> `public String getCategoryTypeName()`

## 기타
- 앞 PR에서 말해주셨던 sublist의 0부터 시작 부분은 이슈 따로 빼서 진행하겠습니다!
https://github.com/prgrms-web-devcourse/Team-10jo-10wonmoa-BE/issues/140