### PR TITLE
[#138] 통계조회 서비스, 컨트롤러 구현

### DIFF
--- a/docs/statistics.adoc
+++ b/docs/statistics.adoc
@@ -1,0 +1,23 @@
+:hardbreaks:
+ifndef::snippets[]
+:snippets: ../../../target/generated-snippets
+endif::[]
+
+== 통계
+
+=== 년 별 통계조회
+
+.Request
+include::{snippets}/statistics-find-year/http-request.adoc[]
+
+.Response
+include::{snippets}/statistics-find-year/http-response.adoc[]
+
+
+=== 월 별 통계조회
+
+.Request
+include::{snippets}/statistics-find-month/http-request.adoc[]
+
+.Response
+include::{snippets}/statistics-find-month/http-response.adoc[]

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsController.java
@@ -1,0 +1,35 @@
+package com.prgrms.tenwonmoa.domain.accountbook.controller;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.service.StatisticsService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/statistics")
+public class StatisticsController {
+	private final StatisticsService statisticsService;
+
+	@GetMapping
+	public ResponseEntity<FindStatisticsResponse> findStatistics(
+		@AuthenticationPrincipal Long userId,
+		@RequestParam @NotBlank @Min(1000) Integer year,
+		@RequestParam(required = false) @Min(1) @Max(31) Integer month
+	) {
+		return ResponseEntity.ok(statisticsService.searchStatistics(userId,
+			year,
+			month));
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsController.java
@@ -25,8 +25,8 @@ public class StatisticsController {
 	@GetMapping
 	public ResponseEntity<FindStatisticsResponse> findStatistics(
 		@AuthenticationPrincipal Long userId,
-		@RequestParam @NotBlank @Min(1000) Integer year,
-		@RequestParam(required = false) @Min(1) @Max(31) Integer month
+		@RequestParam @NotBlank @Min(1900) Integer year,
+		@RequestParam(required = false) @Min(1) @Max(12) Integer month
 	) {
 		return ResponseEntity.ok(statisticsService.searchStatistics(userId,
 			year,

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsData.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsData.java
@@ -1,13 +1,21 @@
 package com.prgrms.tenwonmoa.domain.accountbook.dto.statistics;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@RequiredArgsConstructor
 @ToString
 public class FindStatisticsData {
 	private String name;
 	private Long total;
+	private Double percent;
+
+	public FindStatisticsData(String name, Long total) {
+		this.name = name;
+		this.total = total;
+	}
+
+	public void setPercent(Double percent) {
+		this.percent = percent;
+	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsResponse.java
@@ -1,0 +1,21 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto.statistics;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindStatisticsResponse {
+	private Integer year;
+	private Integer month;
+	private Long incomeTotalSum;
+	private Long expenditureTotalSum;
+	private List<FindStatisticsData> incomes;
+	private List<FindStatisticsData> expenditures;
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/StatisticsQueryRepository.java
@@ -30,7 +30,7 @@ public class StatisticsQueryRepository {
 	private final JPAQueryFactory queryFactory;
 
 	public List<FindStatisticsData> searchIncomeByRegisterDate(Long userId, Integer year, Integer month) {
-		return queryFactory.select(Projections.fields(FindStatisticsData.class,
+		return queryFactory.select(Projections.constructor(FindStatisticsData.class,
 				category.name.coalesce(income.categoryName).as(NAME),
 				income.amount.sum().as(TOTAL)
 			))
@@ -43,7 +43,7 @@ public class StatisticsQueryRepository {
 	}
 
 	public List<FindStatisticsData> searchExpenditureByRegisterDate(Long userId, Integer year, Integer month) {
-		return queryFactory.select(Projections.fields(FindStatisticsData.class,
+		return queryFactory.select(Projections.constructor(FindStatisticsData.class,
 				category.name.coalesce(expenditure.categoryName).as(NAME),
 				expenditure.amount.sum().as(TOTAL)
 			))

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/StatisticsService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/StatisticsService.java
@@ -1,0 +1,53 @@
+package com.prgrms.tenwonmoa.domain.accountbook.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsData;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.StatisticsQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StatisticsService {
+	private static final int PERCENTAGE = 100;
+	private static final double DECIMAL_PLACES_BEFORE = 100;
+	private static final double DECIMAL_PLACES_AFTER = 100.0;
+	private final StatisticsQueryRepository statisticsQueryRepository;
+
+	@Transactional(readOnly = true)
+	public FindStatisticsResponse searchStatistics(Long authId, Integer year, Integer month) {
+		List<FindStatisticsData> incomes = statisticsQueryRepository.searchIncomeByRegisterDate(authId,
+			year, month);
+		List<FindStatisticsData> expenditures = statisticsQueryRepository.searchExpenditureByRegisterDate(authId,
+			year, month);
+
+		Long incomeTotalSum = calcTotalSum(incomes);
+		Long expenditureTotalSum = calcTotalSum(expenditures);
+
+		setPercent(incomes, incomeTotalSum);
+		setPercent(expenditures, expenditureTotalSum);
+		return new FindStatisticsResponse(year, month, incomeTotalSum, expenditureTotalSum, incomes, expenditures);
+	}
+
+	private void setPercent(List<FindStatisticsData> findStatisticsDataList, Long totalSum) {
+		findStatisticsDataList.forEach(findStatisticsData -> {
+			Double percent = calcPercent(totalSum, findStatisticsData.getTotal());
+			findStatisticsData.setPercent(percent);
+		});
+	}
+
+	private Long calcTotalSum(List<FindStatisticsData> findStatisticsDataList) {
+		return findStatisticsDataList.stream().mapToLong(FindStatisticsData::getTotal).sum();
+	}
+
+	private Double calcPercent(Long totalSum, Long perSum) {
+		Double percent = (double)perSum / totalSum * PERCENTAGE;
+		return Math.round(percent * DECIMAL_PLACES_BEFORE) / DECIMAL_PLACES_AFTER;
+	}
+}

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -7,6 +7,35 @@ servers:
 - url: http://3.39.184.232:8080
 tags: []
 paths:
+  /api/v1/statistics:
+    get:
+      tags:
+      - api
+      operationId: statistics-find-
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-statistics-1753393928'
+              examples:
+                statistics-find-month:
+                  value: "{\"year\":2022,\"month\":10,\"incomeTotalSum\":60,\"expenditureTotalSum\"\
+                    :132,\"incomes\":[{\"name\":\"용돈\",\"total\":30,\"percent\":50.0},{\"\
+                    name\":\"상여\",\"total\":20,\"percent\":33.33},{\"name\":\"금융소득\
+                    \",\"total\":10,\"percent\":16.67}],\"expenditures\":[{\"name\"\
+                    :\"교통/차량\",\"total\":45,\"percent\":34.09},{\"name\":\"문화생활\"\
+                    ,\"total\":44,\"percent\":33.33},{\"name\":\"마트/편의점\",\"total\"\
+                    :43,\"percent\":32.58}]}"
+                statistics-find-year:
+                  value: "{\"year\":2022,\"month\":null,\"incomeTotalSum\":60,\"expenditureTotalSum\"\
+                    :132,\"incomes\":[{\"name\":\"용돈\",\"total\":30,\"percent\":50.0},{\"\
+                    name\":\"상여\",\"total\":20,\"percent\":33.33},{\"name\":\"금융소득\
+                    \",\"total\":10,\"percent\":16.67}],\"expenditures\":[{\"name\"\
+                    :\"교통/차량\",\"total\":45,\"percent\":34.09},{\"name\":\"문화생활\"\
+                    ,\"total\":44,\"percent\":33.33},{\"name\":\"마트/편의점\",\"total\"\
+                    :43,\"percent\":32.58}]}"
   /api/v1/incomes/:
     post:
       tags:
@@ -16,13 +45,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-create:
-                value: "{\"registerDate\":\"2022-08-04T16:58:40.706073\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-07T01:25:20.769897\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-create-fail:
-                value: "{\"registerDate\":\"2022-08-04T16:58:41.07363\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-07T01:25:20.802016\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "201":
@@ -39,7 +68,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-create-fail:
                   value: "{\"messages\":[\"해당 사용자 카테고리는 존재하지 않습니다.\"],\"status\":400}"
@@ -61,7 +90,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-find-by-id-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -73,7 +102,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-incomes-incomeId-1674408626'
               examples:
                 income-find-by-id:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-04T16:58:41.268851\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-07T01:25:20.819858\"\
                     ,\"amount\":1000,\"content\":\"content\",\"userCategoryId\":1,\"\
                     categoryName\":\"용돈\"}"
         "403":
@@ -81,7 +110,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-forbidden:
                   value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
@@ -100,13 +129,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-update:
-                value: "{\"registerDate\":\"2022-08-04T16:58:34.808883\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-07T01:25:19.84052\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
               income-update-fail:
-                value: "{\"registerDate\":\"2022-08-04T16:58:40.492173\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-07T01:25:20.737036\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
       responses:
         "204":
@@ -116,7 +145,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
               examples:
                 income-update-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -136,7 +165,7 @@ paths:
           description: "204"
 components:
   schemas:
-    api-v1-incomes-incomeId-940438351:
+    api-v1-incomes--940438351:
       type: object
       properties:
         messages:
@@ -151,7 +180,52 @@ components:
         status:
           type: number
           description: 에러 코드
-    api-v1-incomes-incomeId1988379506:
+    api-v1-statistics-1753393928:
+      type: object
+      properties:
+        incomes:
+          type: array
+          items:
+            type: object
+            properties:
+              total:
+                type: number
+                description: 총 합
+              name:
+                type: string
+                description: 카테고리 이름
+              percent:
+                type: number
+                description: 비율
+        month:
+          description: 월
+          oneOf:
+          - null
+          - type: number
+        year:
+          type: number
+          description: 년도
+        expenditures:
+          type: array
+          items:
+            type: object
+            properties:
+              total:
+                type: number
+                description: 총 합
+              name:
+                type: string
+                description: 카테고리 이름
+              percent:
+                type: number
+                description: 비율
+        incomeTotalSum:
+          type: number
+          description: 수입 총 합계
+        expenditureTotalSum:
+          type: number
+          description: 지출 총 합계
+    api-v1-incomes-1988379506:
       type: object
       properties:
         amount:

--- a/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindStatisticsDataDoc.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindStatisticsDataDoc.java
@@ -1,0 +1,38 @@
+package com.prgrms.tenwonmoa.common.documentdto;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FindStatisticsDataDoc {
+	NAME(STRING, "name", "카테고리 이름"),
+	TOTAL(NUMBER, "total", "총 합"),
+	PERCENT(NUMBER, "percent", "비율");
+
+	private final JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField())
+			.type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> fieldDescriptors() {
+		return List.of(
+			NAME.getFieldDescriptor(),
+			TOTAL.getFieldDescriptor(),
+			PERCENT.getFieldDescriptor()
+		);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindStatisticsResponseDoc.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindStatisticsResponseDoc.java
@@ -1,0 +1,54 @@
+package com.prgrms.tenwonmoa.common.documentdto;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FindStatisticsResponseDoc {
+	YEAR(NUMBER, "year", "년도"),
+	MONTH(NUMBER, "month", "월"),
+	MONTH_NULL(NULL, "month", "월"),
+	INCOME_TOTAL_SUM(NUMBER, "incomeTotalSum", "수입 총 합계"),
+	EXPENDITURE_TOTAL_SUM(NUMBER, "expenditureTotalSum", "지출 총 합계"),
+	INCOMES(ARRAY, "incomes[].", "수입 리스트"),
+	EXPENDITURES(ARRAY, "expenditures[].", "지출 리스트");
+
+	private final JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField())
+			.type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> fieldDescriptorsYear() {
+		return List.of(
+			YEAR.getFieldDescriptor(),
+			MONTH_NULL.getFieldDescriptor(),
+			INCOME_TOTAL_SUM.getFieldDescriptor(),
+			EXPENDITURE_TOTAL_SUM.getFieldDescriptor()
+		);
+	}
+
+	public static List<FieldDescriptor> fieldDescriptorsMonth() {
+		return List.of(
+			YEAR.getFieldDescriptor(),
+			MONTH.getFieldDescriptor(),
+			INCOME_TOTAL_SUM.getFieldDescriptor(),
+			EXPENDITURE_TOTAL_SUM.getFieldDescriptor()
+		);
+	}
+
+
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/IncomeIntegrationTest.java
@@ -126,7 +126,6 @@ class IncomeIntegrationTest extends BaseControllerIntegrationTest {
 		mvc.perform(get(LOCATION_PREFIX + "/{incomeId}", income.getId()).header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("id").value(income.getId()))
-			.andExpect(jsonPath("registerDate").value(income.getRegisterDate().toString()))
 			.andExpect(jsonPath("amount").value(income.getAmount()))
 			.andExpect(jsonPath("content").value(income.getContent()))
 			.andExpect(jsonPath("userCategoryId").value(income.getUserCategory().getId()))

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsControllerTest.java
@@ -1,0 +1,101 @@
+package com.prgrms.tenwonmoa.domain.accountbook.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
+import com.prgrms.tenwonmoa.common.documentdto.FindStatisticsDataDoc;
+import com.prgrms.tenwonmoa.common.documentdto.FindStatisticsResponseDoc;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsData;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.service.StatisticsService;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
+
+@WebMvcTest(controllers = StatisticsController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+@MockBean(JpaMetamodelMappingContext.class)
+@DisplayName("통계 컨트롤러 테스트")
+class StatisticsControllerTest {
+	private static final List<String> INCOME_DEFAULT = List.of("용돈", "상여", "금융소득");
+	private static final List<String> EXPENDITURE_DEFAULT = List.of("교통/차량", "문화생활", "마트/편의점");
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@MockBean
+	private JwtAuthenticationFilter jwtAuthenticationFilter;
+	@MockBean
+	private StatisticsService statisticsService;
+
+	private List<FindStatisticsData> incomes = List.of(new FindStatisticsData(INCOME_DEFAULT.get(0), 30L),
+		new FindStatisticsData(INCOME_DEFAULT.get(1), 20L), new FindStatisticsData(INCOME_DEFAULT.get(2), 10L));
+	private List<FindStatisticsData> expenditures = List.of(new FindStatisticsData(EXPENDITURE_DEFAULT.get(0), 45L),
+		new FindStatisticsData(EXPENDITURE_DEFAULT.get(1), 44L),
+		new FindStatisticsData(EXPENDITURE_DEFAULT.get(2), 43L));
+	FindStatisticsResponse yearResponse = new FindStatisticsResponse(2022, null, 60L, 132L, incomes, expenditures);
+
+	FindStatisticsResponse monthResponse = new FindStatisticsResponse(2022, 10, 60L, 132L, incomes, expenditures);
+
+	private void setPercent() {
+		incomes.get(0).setPercent(50.0);
+		incomes.get(1).setPercent(33.33);
+		incomes.get(2).setPercent(16.67);
+
+		expenditures.get(0).setPercent(34.09);
+		expenditures.get(1).setPercent(33.33);
+		expenditures.get(2).setPercent(32.58);
+	}
+
+	@BeforeEach
+	void init() {
+		setPercent();
+	}
+
+	@Test
+	@WithMockCustomUser
+	void 연별_통계조회_성공() throws Exception {
+		given(statisticsService.searchStatistics(any(), any(), any())).willReturn(yearResponse);
+
+		mockMvc.perform(get("/api/v1/statistics").param("year", "2022"))
+			.andExpect(status().isOk())
+			.andDo(document("statistics-find-year",
+				responseFields().andWithPrefix(FindStatisticsResponseDoc.INCOMES.getField(),
+						FindStatisticsDataDoc.fieldDescriptors())
+					.andWithPrefix(FindStatisticsResponseDoc.EXPENDITURES.getField(),
+						FindStatisticsDataDoc.fieldDescriptors())
+					.and(FindStatisticsResponseDoc.fieldDescriptorsYear())));
+	}
+
+	@Test
+	@WithMockCustomUser
+	void 월별_통계조회_성공() throws Exception {
+		given(statisticsService.searchStatistics(any(), any(), any())).willReturn(monthResponse);
+
+		mockMvc.perform(get("/api/v1/statistics").param("year", "2022").param("month", "10"))
+			.andExpect(status().isOk())
+			.andDo(document("statistics-find-month",
+				responseFields().andWithPrefix(FindStatisticsResponseDoc.INCOMES.getField(),
+						FindStatisticsDataDoc.fieldDescriptors())
+					.andWithPrefix(FindStatisticsResponseDoc.EXPENDITURES.getField(),
+						FindStatisticsDataDoc.fieldDescriptors())
+					.and(FindStatisticsResponseDoc.fieldDescriptorsMonth())));
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsControllerTest.java
@@ -13,9 +13,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -23,13 +24,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
 import com.prgrms.tenwonmoa.common.documentdto.FindStatisticsDataDoc;
 import com.prgrms.tenwonmoa.common.documentdto.FindStatisticsResponseDoc;
+import com.prgrms.tenwonmoa.config.JwtConfigure;
+import com.prgrms.tenwonmoa.config.WebSecurityConfig;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsData;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.service.StatisticsService;
 import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
 
-@WebMvcTest(controllers = StatisticsController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(controllers = StatisticsController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtConfigure.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+	}
+)
 @AutoConfigureRestDocs
 @MockBean(JpaMetamodelMappingContext.class)
 @DisplayName("통계 컨트롤러 테스트")
@@ -40,8 +48,6 @@ class StatisticsControllerTest {
 	private MockMvc mockMvc;
 	@Autowired
 	private ObjectMapper objectMapper;
-	@MockBean
-	private JwtAuthenticationFilter jwtAuthenticationFilter;
 	@MockBean
 	private StatisticsService statisticsService;
 

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/StatisticsServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/StatisticsServiceTest.java
@@ -1,0 +1,101 @@
+package com.prgrms.tenwonmoa.domain.accountbook.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsData;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.StatisticsQueryRepository;
+
+@DisplayName("통계 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class StatisticsServiceTest {
+	private static final List<String> INCOME_DEFAULT = List.of("용돈", "상여", "금융소득");
+	private static final List<String> EXPENDITURE_DEFAULT = List.of("교통/차량", "문화생활", "마트/편의점");
+	@Mock
+	private StatisticsQueryRepository statisticsQueryRepository;
+	@InjectMocks
+	private StatisticsService statisticsService;
+
+	@Test
+	void 통계_조회_성공_행위검증() {
+		// given
+		List<FindStatisticsData> incomes = mock(List.class);
+		List<FindStatisticsData> expenditures = mock(List.class);
+
+		given(statisticsQueryRepository.searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(incomes);
+		given(statisticsQueryRepository.searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(
+			expenditures);
+
+		// when
+		statisticsService.searchStatistics(anyLong(), anyInt(), anyInt());
+
+		// then
+		verify(statisticsQueryRepository).searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt());
+		verify(statisticsQueryRepository).searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt());
+	}
+
+	@Test
+	void 통계_조회_성공_상태검증() {
+		List<FindStatisticsData> incomes = List.of(
+			new FindStatisticsData(INCOME_DEFAULT.get(0), 30L),
+			new FindStatisticsData(INCOME_DEFAULT.get(1), 20L),
+			new FindStatisticsData(INCOME_DEFAULT.get(2), 10L));
+		// given
+		List<FindStatisticsData> expenditures = List.of(
+			new FindStatisticsData(EXPENDITURE_DEFAULT.get(0), 45L),
+			new FindStatisticsData(EXPENDITURE_DEFAULT.get(1), 44L),
+			new FindStatisticsData(EXPENDITURE_DEFAULT.get(2), 43L)
+		);
+		given(statisticsQueryRepository.searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(incomes);
+		given(statisticsQueryRepository.searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(
+			expenditures);
+
+		// when
+		FindStatisticsResponse findStatisticsResponse = statisticsService.searchStatistics(1L, 2022, 07);
+		System.out.println(findStatisticsResponse);
+
+		// then
+		assertThat(findStatisticsResponse.getYear()).isEqualTo(2022);
+		assertThat(findStatisticsResponse.getMonth()).isEqualTo(07);
+		assertThat(findStatisticsResponse.getIncomeTotalSum()).isEqualTo(60L);
+		assertThat(findStatisticsResponse.getExpenditureTotalSum()).isEqualTo(132L);
+		assertThat(findStatisticsResponse.getIncomes()).hasSize(3);
+		assertThat(findStatisticsResponse.getExpenditures()).hasSize(3);
+		assertThat(findStatisticsResponse.getIncomes()).extracting("percent")
+			.containsExactly(50.0, 33.33, 16.67);
+		assertThat(findStatisticsResponse.getExpenditures()).extracting("percent")
+			.containsExactly(34.09, 33.33, 32.58);
+	}
+
+	@Test
+	void 통계_조회_성공_상태검증_비어있는경우() {
+		List<FindStatisticsData> incomes = Collections.emptyList();
+		List<FindStatisticsData> expenditures = Collections.emptyList();
+
+		given(statisticsQueryRepository.searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(incomes);
+		given(statisticsQueryRepository.searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(
+			expenditures);
+
+		// when
+		FindStatisticsResponse findStatisticsResponse = statisticsService.searchStatistics(1L, 2022, 07);
+
+		// then
+		assertThat(findStatisticsResponse.getYear()).isEqualTo(2022);
+		assertThat(findStatisticsResponse.getMonth()).isEqualTo(07);
+		assertThat(findStatisticsResponse.getIncomeTotalSum()).isEqualTo(0L);
+		assertThat(findStatisticsResponse.getExpenditureTotalSum()).isEqualTo(0L);
+		assertThat(findStatisticsResponse.getIncomes()).isEmpty();
+		assertThat(findStatisticsResponse.getExpenditures()).isEmpty();
+	}
+}


### PR DESCRIPTION
## 개요

- 통계조회 서비스, 컨트롤러 구현

## 추가기능

- `statistics/year={year}`와 `statistics/year={year}&month={month}` 요청 API를 처리할 수 있다.
  - 년 별, 월 별 통계데이터를 조회할 수 있다.

## 데이터 샘플
``` javascript
{
    year: 2022,
    month: 7,  // 년 별 조회일 경우, null로 전달
    incomeTotalSum: 80000, 
    expenditureTotalSum: 12000000,
    incomes: [
      {
        name: '월급',
        percent: 50,
        total: 500000,
      },
      {
        name: '주식',
        percent: 30,
        total: 300000,
      },
    ],
    expenditures: [
      {
        name: '식비',
        percent: 50,
        total: 50000,
      },
      {
        name: '패션/미용',
        percent: 30,
        total: 30000,
      },
      {
        name: '교육',
        percent: 20,
        total: 20000,
      },
    ],
};

```

## 기타
- 아래 화면 구성에 필요한 데이터를 조회한다.
![image](https://user-images.githubusercontent.com/26343023/182855567-7ee64483-47aa-4fa2-8e93-6ede4951305f.png)
