### PR TITLE
[#144] 통계조회 통합테스트 및 유효성검사 추가

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsController.java
@@ -1,16 +1,14 @@
 package com.prgrms.tenwonmoa.domain.accountbook.controller;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
+import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.service.StatisticsService;
 
@@ -25,11 +23,10 @@ public class StatisticsController {
 	@GetMapping
 	public ResponseEntity<FindStatisticsResponse> findStatistics(
 		@AuthenticationPrincipal Long userId,
-		@RequestParam @NotBlank @Min(1900) Integer year,
-		@RequestParam(required = false) @Min(1) @Max(12) Integer month
+		@Valid FindStatisticsRequest findStatisticsRequest
 	) {
 		return ResponseEntity.ok(statisticsService.searchStatistics(userId,
-			year,
-			month));
+			findStatisticsRequest.getYear(),
+			findStatisticsRequest.getMonth()));
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsRequest.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/statistics/FindStatisticsRequest.java
@@ -1,0 +1,20 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto.statistics;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.Range;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindStatisticsRequest {
+	@NotNull
+	@Min(value = 1900, message = "연도의 최솟값은 1900입니다.")
+	Integer year;
+
+	@Range(min = 1, max = 12, message = "월은 1~12 범위만 입력할 수 있습니다.")
+	Integer month;
+}

--- a/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
@@ -8,9 +8,9 @@ import java.util.stream.Collectors;
 
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -57,8 +57,8 @@ public class GlobalExceptionHandler {
 			.body(errorResponse);
 	}
 
-	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ResponseEntity<ErrorResponse> handleAlreadyExistException(MethodArgumentNotValidException exception) {
+	@ExceptionHandler(BindException.class)
+	public ResponseEntity<ErrorResponse> handleAlreadyExistException(BindException exception) {
 		BindingResult bindingResult = exception.getBindingResult();
 		List<String> errors = bindingResult.getAllErrors()
 			.stream()

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsIntegrationTest.java
@@ -3,7 +3,6 @@ package com.prgrms.tenwonmoa.domain.accountbook.controller;
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
 import static java.time.LocalDateTime.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
@@ -58,6 +57,7 @@ class StatisticsIntegrationTest extends BaseControllerIntegrationTest {
 			new Income(registerDate, amount, "content", userCategory.getCategoryName(), userCategory.getUser(),
 				userCategory));
 	}
+
 	public Expenditure saveExpenditure(UserCategory userCategory, Long amount, LocalDateTime registerDate) {
 		return expenditureRepository.saveAndFlush(
 			new Expenditure(registerDate, amount, "content", userCategory.getCategoryName(), userCategory.getUser(),
@@ -70,7 +70,7 @@ class StatisticsIntegrationTest extends BaseControllerIntegrationTest {
 		loginUser = userRepository.findByEmail("testuser@gmail.com").get();
 		category = categoryRepository.save(createIncomeCategory());
 		userCategory = userCategoryRepository.save(createUserCategory(loginUser, category));
-		saveSampleData();
+		initData();
 	}
 
 	@AfterEach
@@ -84,7 +84,9 @@ class StatisticsIntegrationTest extends BaseControllerIntegrationTest {
 
 	@Test
 	void 통계_년별조회_성공() throws Exception {
-		mvc.perform(get(LOCATION_PREFIX).param(YEAR, "2021").header(HttpHeaders.AUTHORIZATION, accessToken))
+		mvc.perform(get(LOCATION_PREFIX)
+				.param(YEAR, "2021")
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("year").value(2021))
 			.andExpect(jsonPath("month").isEmpty())
@@ -97,7 +99,10 @@ class StatisticsIntegrationTest extends BaseControllerIntegrationTest {
 	@Test
 	void 통계_월별조회_성공() throws Exception {
 		mvc.perform(
-				get(LOCATION_PREFIX).param(YEAR, "2021").param(MONTH, "7").header(HttpHeaders.AUTHORIZATION, accessToken))
+				get(LOCATION_PREFIX)
+					.param(YEAR, "2021")
+					.param(MONTH, "7")
+					.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("year").value(2021))
 			.andExpect(jsonPath("month").value(7))
@@ -109,8 +114,10 @@ class StatisticsIntegrationTest extends BaseControllerIntegrationTest {
 
 	@Test
 	void 통계_월앞에0붙였을때_성공() throws Exception {
-		mvc.perform(
-				get(LOCATION_PREFIX).param(YEAR, "2021").param(MONTH, "07").header(HttpHeaders.AUTHORIZATION, accessToken))
+		mvc.perform(get(LOCATION_PREFIX)
+				.param(YEAR, "2021")
+				.param(MONTH, "07")
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("year").value(2021))
 			.andExpect(jsonPath("month").value(07))
@@ -140,14 +147,15 @@ class StatisticsIntegrationTest extends BaseControllerIntegrationTest {
 	}
 
 	private void validateSearchStatistics(String year, String month, String expectMessage) throws Exception {
-		mvc.perform(
-				get(LOCATION_PREFIX).param(YEAR, year).param(MONTH, month).header(HttpHeaders.AUTHORIZATION, accessToken))
-			.andDo(print())
+		mvc.perform(get(LOCATION_PREFIX)
+				.param(YEAR, year)
+				.param(MONTH, month)
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("messages").value(expectMessage));
 	}
 
-	private void saveSampleData() {
+	private void initData() {
 		saveIncome(userCategory, 100L, of(2021, 7, 1, 0, 0, 0));
 		saveIncome(userCategory, 200L, of(2021, 6, 5, 0, 0, 0));
 		saveIncome(userCategory, 700L, of(2021, 5, 13, 0, 0, 0));

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/StatisticsIntegrationTest.java
@@ -1,0 +1,160 @@
+package com.prgrms.tenwonmoa.domain.accountbook.controller;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static java.time.LocalDateTime.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.tenwonmoa.common.BaseControllerIntegrationTest;
+import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.category.repository.CategoryRepository;
+import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
+
+@DisplayName("통계 컨트롤러 통합 테스트")
+class StatisticsIntegrationTest extends BaseControllerIntegrationTest {
+	private static final String LOCATION_PREFIX = "/api/v1/statistics";
+	private static final String YEAR = "year";
+	private static final String MONTH = "month";
+	private static final String YEAR_MIN_EXP_MSG = "연도의 최솟값은 1900입니다.";
+	private static final String MONTH_EXP_MSG = "월은 1~12 범위만 입력할 수 있습니다.";
+	private static final String MUST_NOT_BE_NULL = "must not be null";
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private UserCategoryRepository userCategoryRepository;
+	@Autowired
+	private IncomeRepository incomeRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private ExpenditureRepository expenditureRepository;
+
+	private User loginUser;
+	private Category category;
+	private UserCategory userCategory;
+
+	private Income saveIncome(UserCategory userCategory, Long amount, LocalDateTime registerDate) {
+		return incomeRepository.saveAndFlush(
+			new Income(registerDate, amount, "content", userCategory.getCategoryName(), userCategory.getUser(),
+				userCategory));
+	}
+	public Expenditure saveExpenditure(UserCategory userCategory, Long amount, LocalDateTime registerDate) {
+		return expenditureRepository.saveAndFlush(
+			new Expenditure(registerDate, amount, "content", userCategory.getCategoryName(), userCategory.getUser(),
+				userCategory));
+	}
+
+	@BeforeEach
+	void init() throws Exception {
+		registerUserAndLogin();
+		loginUser = userRepository.findByEmail("testuser@gmail.com").get();
+		category = categoryRepository.save(createIncomeCategory());
+		userCategory = userCategoryRepository.save(createUserCategory(loginUser, category));
+		saveSampleData();
+	}
+
+	@AfterEach
+	void clear() {
+		incomeRepository.deleteAllInBatch();
+		expenditureRepository.deleteAllInBatch();
+		userCategoryRepository.deleteAllInBatch();
+		userRepository.deleteAllInBatch();
+		categoryRepository.deleteAllInBatch();
+	}
+
+	@Test
+	void 통계_년별조회_성공() throws Exception {
+		mvc.perform(get(LOCATION_PREFIX).param(YEAR, "2021").header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("year").value(2021))
+			.andExpect(jsonPath("month").isEmpty())
+			.andExpect(jsonPath("incomeTotalSum").value(1000))
+			.andExpect(jsonPath("expenditureTotalSum").value(400))
+			.andExpect(jsonPath("incomes").exists())
+			.andExpect(jsonPath("expenditures").exists());
+	}
+
+	@Test
+	void 통계_월별조회_성공() throws Exception {
+		mvc.perform(
+				get(LOCATION_PREFIX).param(YEAR, "2021").param(MONTH, "7").header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("year").value(2021))
+			.andExpect(jsonPath("month").value(7))
+			.andExpect(jsonPath("incomeTotalSum").value(100))
+			.andExpect(jsonPath("expenditureTotalSum").value(200))
+			.andExpect(jsonPath("incomes").exists())
+			.andExpect(jsonPath("expenditures").exists());
+	}
+
+	@Test
+	void 통계_월앞에0붙였을때_성공() throws Exception {
+		mvc.perform(
+				get(LOCATION_PREFIX).param(YEAR, "2021").param(MONTH, "07").header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("year").value(2021))
+			.andExpect(jsonPath("month").value(07))
+			.andExpect(jsonPath("incomeTotalSum").value(100))
+			.andExpect(jsonPath("expenditureTotalSum").value(200))
+			.andExpect(jsonPath("incomes").exists())
+			.andExpect(jsonPath("expenditures").exists());
+	}
+
+	@Test
+	void 통계_Valid_월만입력된경우() throws Exception {
+		validateSearchStatistics(null, "10", MUST_NOT_BE_NULL);
+	}
+
+	@Test
+	void 통계_Valid_년도는_1900이상만_가능() throws Exception {
+		validateSearchStatistics("1899", "10", YEAR_MIN_EXP_MSG);
+		validateSearchStatistics("0", "10", YEAR_MIN_EXP_MSG);
+		validateSearchStatistics("-1", "10", YEAR_MIN_EXP_MSG);
+	}
+
+	@Test
+	void 통계_Valid_잘못된_월_입력() throws Exception {
+		validateSearchStatistics("2020", "-1", MONTH_EXP_MSG);
+		validateSearchStatistics("2020", "0", MONTH_EXP_MSG);
+		validateSearchStatistics("2020", "13", MONTH_EXP_MSG);
+	}
+
+	private void validateSearchStatistics(String year, String month, String expectMessage) throws Exception {
+		mvc.perform(
+				get(LOCATION_PREFIX).param(YEAR, year).param(MONTH, month).header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("messages").value(expectMessage));
+	}
+
+	private void saveSampleData() {
+		saveIncome(userCategory, 100L, of(2021, 7, 1, 0, 0, 0));
+		saveIncome(userCategory, 200L, of(2021, 6, 5, 0, 0, 0));
+		saveIncome(userCategory, 700L, of(2021, 5, 13, 0, 0, 0));
+
+		saveExpenditure(userCategory, 100L, of(2021, 7, 6, 0, 0, 0));
+		saveExpenditure(userCategory, 100L, of(2021, 7, 9, 0, 0, 0));
+		saveExpenditure(userCategory, 100L, of(2021, 1, 2, 0, 0, 0));
+		saveExpenditure(userCategory, 100L, of(2021, 2, 1, 0, 0, 0));
+	}
+}


### PR DESCRIPTION
## 개요
- 통계조회 통합테스트 및 유효성검사 추가

## 추가기능
- 통합테스트
- 컨트롤러 유효성 검사

## 변경사항(Optional)
- GlobalExceptionHandler에서 기존 `MethodArgumentNotValidException` 예외를 부모클래스인 `BindException`로 변경했습니다. 
  - 년도가 null인 경우, BindingException이 먼저 처리되어서 공통으로적용하고자 변경했습니다.

## 사용방법(Optional)
- 년 조건으로 통계를 조회할 수 있다.
  - 년 조건은 1900년도 이상부터 조회가능하다.

- 월 조건으로 통계를 조회할 수 있다.
  - 월 조건은 반드시 연도가 포함되어야 한다.
  - 월 조건은 1~12만 조회가능하다.
