### PR TITLE
[#127] 월별 탭 api 작성 - 월별 상세 내역 + 연간 합계 내역

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
@@ -44,7 +44,7 @@ public class AccountBookQueryController {
 		return ResponseEntity.ok().body(response);
 	}
 
-	@GetMapping("/sum/{date}")
+	@GetMapping("/sum/month/{date}")
 	public ResponseEntity<FindSumResponse> findMonthSum(
 		@AuthenticationPrincipal Long userId,
 		@PathVariable
@@ -55,7 +55,7 @@ public class AccountBookQueryController {
 		return ResponseEntity.ok(response);
 	}
 
-	@GetMapping("/sum/{year}")
+	@GetMapping("/sum/year/{year}")
 	public ResponseEntity<FindSumResponse> findYearSum(
 		@AuthenticationPrincipal Long userId,
 		@PathVariable int year

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
@@ -1,6 +1,7 @@
 package com.prgrms.tenwonmoa.domain.accountbook.controller;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.MonthCondition;
 import com.prgrms.tenwonmoa.domain.accountbook.service.AccountBookQueryService;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
@@ -67,7 +69,8 @@ public class AccountBookQueryController {
 		@AuthenticationPrincipal Long userId,
 		@PathVariable int year
 	) {
-		FindMonthAccountResponse response = accountBookQueryService.findMonthAccount(userId, year);
+		MonthCondition condition = new MonthCondition(LocalDateTime.now(), year);
+		FindMonthAccountResponse response = accountBookQueryService.findMonthAccount(userId, condition);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.service.AccountBookQueryService;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
@@ -51,5 +52,24 @@ public class AccountBookQueryController {
 		FindSumResponse response = accountBookQueryService.findMonthSum(userId, date);
 		return ResponseEntity.ok(response);
 	}
+
+	@GetMapping("/sum/{year}")
+	public ResponseEntity<FindSumResponse> findYearSum(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable int year
+	) {
+		FindSumResponse response = accountBookQueryService.findYearSum(userId, year);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/month/{year}")
+	public ResponseEntity<FindMonthAccountResponse> findMonthAccount(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable int year
+	) {
+		FindMonthAccountResponse response = accountBookQueryService.findMonthAccount(userId, year);
+		return ResponseEntity.ok(response);
+	}
+
 }
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/DayDetail.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/DayDetail.java
@@ -31,7 +31,7 @@ public class DayDetail implements Comparable<DayDetail> {
 
 	/**
 	 * 날짜별 상세 정렬 기준
-	 * 1.type: INCOME, EXPENDITURE 순으로 정렬
+	 * 1.type: EXPENDITURE, INCOME 순으로 정렬
 	 * 2.type이 같으면 등록한 최신 순으로
 	 * */
 	@Override

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindMonthAccountResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindMonthAccountResponse.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 
 @Getter
 public class FindMonthAccountResponse extends ChunksCustom<MonthDetail> {
-	
 	public FindMonthAccountResponse(List<MonthDetail> results) {
 		super(results);
 	}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindMonthAccountResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindMonthAccountResponse.java
@@ -2,14 +2,14 @@ package com.prgrms.tenwonmoa.domain.accountbook.dto;
 
 import java.util.List;
 
+import com.prgrms.tenwonmoa.domain.common.page.ChunksCustom;
+
 import lombok.Getter;
 
 @Getter
-public class FindMonthAccountResponse {
-
-	private final List<MonthDetail> results;
-
+public class FindMonthAccountResponse extends ChunksCustom<MonthDetail> {
+	
 	public FindMonthAccountResponse(List<MonthDetail> results) {
-		this.results = results;
+		super(results);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindMonthAccountResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindMonthAccountResponse.java
@@ -1,0 +1,15 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class FindMonthAccountResponse {
+
+	private final List<MonthDetail> results;
+
+	public FindMonthAccountResponse(List<MonthDetail> results) {
+		this.results = results;
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/MonthCondition.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/MonthCondition.java
@@ -1,0 +1,22 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public class MonthCondition {
+
+	private final LocalDateTime now;
+
+	private final int year;
+
+	private final boolean isFuture;
+
+	public MonthCondition(LocalDateTime now, int year) {
+		this.now = now;
+		this.year = year;
+		isFuture = now.getYear() < year;
+	}
+
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/MonthCondition.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/MonthCondition.java
@@ -1,22 +1,73 @@
 package com.prgrms.tenwonmoa.domain.accountbook.dto;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import lombok.Getter;
 
+/**
+ * now: 애플리케이션상 현재 시각
+ * conditionYear: 클라이언트가 입력한 요청한 년도
+ * isFuture : 요청받은 년도가 미래인지
+ * isPast : 요청받은 년도가 과거인지
+ * **/
 @Getter
 public class MonthCondition {
 
+	private static final List<Integer> allMonth = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+
 	private final LocalDateTime now;
 
-	private final int year;
+	private final int conditionYear;
 
 	private final boolean isFuture;
 
-	public MonthCondition(LocalDateTime now, int year) {
+	private final boolean isPast;
+
+	public MonthCondition(LocalDateTime now, int conditionYear) {
 		this.now = now;
-		this.year = year;
-		isFuture = now.getYear() < year;
+		this.conditionYear = conditionYear;
+		this.isFuture = getNowYear() < conditionYear;
+		this.isPast = getNowYear() > conditionYear;
+	}
+
+	/**
+	 * 과거면 1 ~ 12월 작성한 것이 없더라도 모두 보여주어야 한다
+	 * 현재면 미래 월을작성했다면 미래월부터 1월까지
+	 * 현재면 현재월 이하로 작성되었다면 현재월 ~ 1월까지
+	 * **/
+	public Set<Integer> getNotFutureMonthSet(Set<Integer> monthSet) {
+		Set<Integer> set = new HashSet<>();
+		set.addAll(monthSet);
+
+		if (isPast) {
+			// 과거면 작성하든 하지 않든 모두 보여주어야 한다.
+			set.addAll(allMonth);
+			return set;
+		}
+
+		Integer maxMonth = Collections.max(monthSet);
+		int currMonth = getNowMonth();
+
+		// 현재년도에서 작성된 월과 현재 해당월의 크기 비교
+		int fromMonth = Math.max(currMonth, maxMonth);
+
+		for (int i = 1; i <= fromMonth; i++) {
+			set.add(i);
+		}
+
+		return set;
+	}
+
+	private int getNowYear() {
+		return now.getYear();
+	}
+
+	private int getNowMonth() {
+		return now.getMonthValue();
 	}
 
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/MonthDetail.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/MonthDetail.java
@@ -1,0 +1,14 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MonthDetail extends FindSumResponse {
+
+	private final int month;
+
+	public MonthDetail(Long incomeSum, Long expenditureSum, int month) {
+		super(incomeSum, expenditureSum);
+		this.month = month;
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
@@ -147,7 +147,25 @@ public class AccountBookQueryRepository {
 
 	public FindSumResponse findYearSum(Long userId, int year) {
 
-		return null;
+		Long incomeSum = queryFactory.select(income.amount.sum())
+			.from(income)
+			.groupBy(income.registerDate.year())
+			.where(income.registerDate.year().eq(year),
+				income.user.id.eq(userId)
+			)
+			.fetchOne();
+
+		Long expenditureSum = queryFactory.select(expenditure.amount.sum())
+			.from(expenditure)
+			.groupBy(expenditure.registerDate.year())
+			.where(expenditure.registerDate.year().eq(year),
+				expenditure.user.id.eq(userId)
+			)
+			.fetchOne();
+
+		incomeSum = incomeSum == null ? 0L : incomeSum;
+		expenditureSum = expenditureSum == null ? 0L : expenditureSum;
+		return new FindSumResponse(incomeSum, expenditureSum);
 	}
 
 	private List<LocalDate> getPageDate(PageCustomRequest pageCustomRequest, Long userId, LocalDate date) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
@@ -271,8 +271,5 @@ public class AccountBookQueryRepository {
 	private Long getAmountZeroIfNull(Long amount) {
 		return amount == null ? 0 : amount;
 	}
-
-	private List<MonthDetail> getResults() {
-
-	}
 }
+

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
@@ -17,6 +17,7 @@ import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.DayDetail;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
 import com.prgrms.tenwonmoa.domain.category.CategoryType;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
@@ -138,6 +139,15 @@ public class AccountBookQueryRepository {
 		incomeSum = incomeSum == null ? 0L : incomeSum;
 		expenditureSum = expenditureSum == null ? 0L : expenditureSum;
 		return new FindSumResponse(incomeSum, expenditureSum);
+	}
+
+	public FindMonthAccountResponse findMonthAccount(Long userId, int year) {
+		return null;
+	}
+
+	public FindSumResponse findYearSum(Long userId, int year) {
+
+		return null;
 	}
 
 	private List<LocalDate> getPageDate(PageCustomRequest pageCustomRequest, Long userId, LocalDate date) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
@@ -19,9 +19,11 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.DayDetail;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.MonthCondition;
 import com.prgrms.tenwonmoa.domain.category.CategoryType;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
+import com.querydsl.core.group.GroupBy;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -141,7 +143,26 @@ public class AccountBookQueryRepository {
 		return new FindSumResponse(incomeSum, expenditureSum);
 	}
 
-	public FindMonthAccountResponse findMonthAccount(Long userId, int year) {
+	public FindMonthAccountResponse findMonthAccount(Long userId, MonthCondition condition) {
+		// year가 미래인지 판단
+		// 미래면 사용자가 작성한 월만, 미래가 아니면 전체 작성된 월~
+
+		int year = condition.getYear();
+
+		Map<Integer, Long> expenditureMonthMap = queryFactory.from(expenditure)
+			.where(expenditure.registerDate.year().eq(year))
+			.orderBy(expenditure.registerDate.month().desc())
+			.transform(GroupBy.groupBy(expenditure.registerDate.month())
+				.as(GroupBy.sum(expenditure.amount))
+			);
+
+		Map<Integer, Long> incomeMonthMap = queryFactory.from(income)
+			.where(income.registerDate.year().eq(year))
+			.orderBy(income.registerDate.month().desc())
+			.transform(GroupBy.groupBy(income.registerDate.month())
+				.as(GroupBy.sum(income.amount))
+			);
+
 		return null;
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepository.java
@@ -172,7 +172,7 @@ public class AccountBookQueryRepository {
 		List<Integer> monthList = new ArrayList<>(expenditureMonthMap.keySet());
 		monthList.addAll(incomeMonthMap.keySet());
 
-		List<MonthDetail> results = getMonthDetails(condition, new HashSet<>(monthList), expenditureMonthMap,
+		List<MonthDetail> results = getMonthAccountResults(condition, new HashSet<>(monthList), expenditureMonthMap,
 			incomeMonthMap);
 
 		return new FindMonthAccountResponse(results);
@@ -201,27 +201,24 @@ public class AccountBookQueryRepository {
 		return new FindSumResponse(incomeSum, expenditureSum);
 	}
 
-	private List<MonthDetail> getMonthDetails(MonthCondition monthCondition, Set<Integer> monthSet,
+	private List<MonthDetail> getMonthAccountResults(MonthCondition monthCondition, Set<Integer> monthSet,
 		Map<Integer, Long> expenditureMap, Map<Integer, Long> incomeMap) {
-		List<MonthDetail> results = new ArrayList<>();
 
 		boolean isFuture = monthCondition.isFuture();
 		if (isFuture) {
-			Iterator<Integer> iter = monthSet.iterator();
-			while (iter.hasNext()) {
-				int month = iter.next();
-				Long incomeSum = getAmountZeroIfNull(incomeMap.get(month));
-				Long expenditureSum = getAmountZeroIfNull(expenditureMap.get(month));
-				results.add(new MonthDetail(incomeSum, expenditureSum, month));
-			}
-			return results.stream()
-				.sorted((d1, d2) -> d1.getMonth() > d2.getMonth() ? -1 : 1)
-				.collect(Collectors.toList());
+			return getMonthDetails(monthSet, expenditureMap, incomeMap);
 		}
 
 		Set<Integer> notFutureMonthSet = monthCondition.getNotFutureMonthSet(monthSet);
 
-		Iterator<Integer> iter = notFutureMonthSet.iterator();
+		return getMonthDetails(notFutureMonthSet, expenditureMap, incomeMap);
+	}
+
+	private List<MonthDetail> getMonthDetails(Set<Integer> monthSet, Map<Integer, Long> expenditureMap,
+		Map<Integer, Long> incomeMap) {
+
+		List<MonthDetail> results = new ArrayList<>();
+		Iterator<Integer> iter = monthSet.iterator();
 		while (iter.hasNext()) {
 			int month = iter.next();
 			Long incomeSum = getAmountZeroIfNull(incomeMap.get(month));
@@ -273,5 +270,9 @@ public class AccountBookQueryRepository {
 
 	private Long getAmountZeroIfNull(Long amount) {
 		return amount == null ? 0 : amount;
+	}
+
+	private List<MonthDetail> getResults() {
+
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookQueryService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookQueryService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.MonthCondition;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.AccountBookQueryRepository;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
@@ -34,7 +35,7 @@ public class AccountBookQueryService {
 		return accountBookQueryRepository.findYearSum(userId, year);
 	}
 
-	public FindMonthAccountResponse findMonthAccount(Long userId, int year) {
-		return accountBookQueryRepository.findMonthAccount(userId, year);
+	public FindMonthAccountResponse findMonthAccount(Long userId, MonthCondition condition) {
+		return accountBookQueryRepository.findMonthAccount(userId, condition);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookQueryService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookQueryService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.AccountBookQueryRepository;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
@@ -27,5 +28,13 @@ public class AccountBookQueryService {
 
 	public FindSumResponse findMonthSum(Long userId, LocalDate monthTime) {
 		return accountBookQueryRepository.findMonthSum(userId, monthTime);
+	}
+
+	public FindSumResponse findYearSum(Long userId, int year) {
+		return accountBookQueryRepository.findYearSum(userId, year);
+	}
+
+	public FindMonthAccountResponse findMonthAccount(Long userId, int year) {
+		return accountBookQueryRepository.findMonthAccount(userId, year);
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
@@ -110,6 +110,53 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 	}
 
 	@Nested
+	@DisplayName("연간 수입과 지출의 합계를 조회")
+	class FindYearSumQuery {
+		@Test
+		public void 수입과_지출_모두_존재할경우() {
+			createExpenditures(10);
+			createIncomes(10);
+
+			FindSumResponse monthSum = accountBookQueryRepository.findYearSum(user.getId(), 2022);
+
+			assertThat(monthSum.getIncomeSum()).isEqualTo(10000L);
+			assertThat(monthSum.getExpenditureSum()).isEqualTo(10000L);
+			assertThat(monthSum.getTotalSum()).isEqualTo(0);
+		}
+
+		@Test
+		public void 수입만_존재할경우() {
+			createIncomes(7);
+
+			FindSumResponse yearSum = accountBookQueryRepository.findYearSum(user.getId(), 2022);
+
+			assertThat(yearSum.getIncomeSum()).isEqualTo(7000L);
+			assertThat(yearSum.getExpenditureSum()).isEqualTo(0L);
+			assertThat(yearSum.getTotalSum()).isEqualTo(7000L);
+		}
+
+		@Test
+		public void 지출만_존재할경우() {
+			createExpenditures(8);
+
+			FindSumResponse yearSum = accountBookQueryRepository.findYearSum(user.getId(), 2022);
+
+			assertThat(yearSum.getIncomeSum()).isEqualTo(0L);
+			assertThat(yearSum.getExpenditureSum()).isEqualTo(8000L);
+			assertThat(yearSum.getTotalSum()).isEqualTo(-8000L);
+		}
+
+		@Test
+		public void 연간_수입과_지출이_없을경우() {
+			FindSumResponse yearSum = accountBookQueryRepository.findYearSum(user.getId(), 2022);
+
+			assertThat(yearSum.getIncomeSum()).isEqualTo(0L);
+			assertThat(yearSum.getExpenditureSum()).isEqualTo(0L);
+			assertThat(yearSum.getTotalSum()).isEqualTo(0L);
+		}
+	}
+
+	@Nested
 	@DisplayName("일별 상세내역 페이징 조회 중")
 	class FindDayAccount {
 

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
@@ -18,7 +18,10 @@ import com.prgrms.tenwonmoa.common.RepositoryTest;
 import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.MonthCondition;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.MonthDetail;
 import com.prgrms.tenwonmoa.domain.category.Category;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
@@ -62,8 +65,8 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 
 		@Test
 		public void 수입과_지출_모두_존재할경우() {
-			createExpenditures(10);
-			createIncomes(10);
+			createExpenditures(10, 2022, 8);
+			createIncomes(10, 2022, 8);
 
 			FindSumResponse monthSum = accountBookQueryRepository.findMonthSum(user.getId(),
 				LocalDate.parse("2022-08-01", DateTimeFormatter.ofPattern("yyyy-MM-dd")));
@@ -75,7 +78,7 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 
 		@Test
 		public void 수입만_존재할경우() {
-			createIncomes(7);
+			createIncomes(7, 2022, 8);
 
 			FindSumResponse monthSum = accountBookQueryRepository.findMonthSum(user.getId(),
 				LocalDate.parse("2022-08-01", DateTimeFormatter.ofPattern("yyyy-MM-dd")));
@@ -87,7 +90,7 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 
 		@Test
 		public void 지출만_존재할경우() {
-			createExpenditures(8);
+			createExpenditures(8, 2022, 8);
 
 			FindSumResponse monthSum = accountBookQueryRepository.findMonthSum(user.getId(),
 				LocalDate.parse("2022-08-01", DateTimeFormatter.ofPattern("yyyy-MM-dd")));
@@ -114,8 +117,8 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 	class FindYearSumQuery {
 		@Test
 		public void 수입과_지출_모두_존재할경우() {
-			createExpenditures(10);
-			createIncomes(10);
+			createExpenditures(10, 2022, 8);
+			createIncomes(10, 2022, 8);
 
 			FindSumResponse monthSum = accountBookQueryRepository.findYearSum(user.getId(), 2022);
 
@@ -126,7 +129,7 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 
 		@Test
 		public void 수입만_존재할경우() {
-			createIncomes(7);
+			createIncomes(7, 2022, 8);
 
 			FindSumResponse yearSum = accountBookQueryRepository.findYearSum(user.getId(), 2022);
 
@@ -137,7 +140,7 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 
 		@Test
 		public void 지출만_존재할경우() {
-			createExpenditures(8);
+			createExpenditures(8, 2022, 8);
 
 			FindSumResponse yearSum = accountBookQueryRepository.findYearSum(user.getId(), 2022);
 
@@ -178,8 +181,8 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 
 		@Test
 		public void 날짜를_수입과_집합의_날짜_합집합을_10개_반환하여_페이징처리한다() {
-			createExpenditures(10);
-			createIncomes(10);
+			createExpenditures(10, 2022, 8);
+			createIncomes(10, 2022, 8);
 
 			PageCustomImpl<FindDayAccountResponse> dailyAccount = accountBookQueryRepository.findDailyAccount(
 				user.getId(),
@@ -204,8 +207,8 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 
 		@Test
 		public void 마지막_페이지일_경우_응답에서_nextPage를_null로_응답한다() {
-			createExpenditures(10);
-			createIncomes(10);
+			createExpenditures(10, 2022, 8);
+			createIncomes(10, 2022, 8);
 
 			PageCustomImpl<FindDayAccountResponse> dailyAccount = accountBookQueryRepository.findDailyAccount(
 				user.getId(),
@@ -222,10 +225,198 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 		}
 	}
 
-	private void createExpenditures(int count) {
+	@Nested
+	@DisplayName("월별 상세내역 조회")
+	class FindMonthAccount {
+
+		LocalDateTime now = LocalDateTime.of(2022, 8, 1, 0, 0);
+		int currentYear = 2022;
+		int pastYear = 2021;
+		int futureYear = 2023;
+
+		@Test
+		public void 현재_년도2022에서_현재월8월보다_작성한내역이_과거일때는_8월부터_1월까지_내역을_보여준다() {
+
+			/**
+			 * given
+			 * 8월 지출: 0, 수입: 0
+			 * 7월 지출: 2000, 수입: 0
+			 * 6월 지출: 2000, 수입: 2000
+			 * 5월 지출: 2000, 수입: 2000
+			 * 4월 지출: 0, 수입: 2000
+			 * 3월 지출: 0, 수입: 2000
+			 * 2월 지출: 0, 수입: 0
+			 * 1월 지출: 0, 수입: 0
+			 */
+			createExpenditures(2, currentYear, 7);
+			createExpenditures(2, currentYear, 6);
+			createExpenditures(2, currentYear, 5);
+			createIncomes(2, currentYear, 6);
+			createIncomes(2, currentYear, 5);
+			createIncomes(2, currentYear, 4);
+			createIncomes(2, currentYear, 3);
+
+			//when
+			FindMonthAccountResponse monthAccount = accountBookQueryRepository.findMonthAccount(user.getId(),
+				new MonthCondition(now, currentYear));
+
+			List<MonthDetail> results = monthAccount.getResults();
+
+			for (int i = 8; i >= 1; i--) {
+				MonthDetail monthDetail = results.get(8 - i);
+
+				if (i == 7) {
+					checkMonthDetail(monthDetail, i, 2000L, 0L, -2000L);
+				}
+
+				if (i == 6 || i == 5) {
+					checkMonthDetail(monthDetail, i, 2000L, 2000L, 0L);
+				}
+
+				if (i == 4 && i <= 3) {
+					checkMonthDetail(monthDetail, i, 0L, 2000L, 2000L);
+				}
+
+				if (i <= 2 || i == 8) {
+					checkMonthDetail(monthDetail, i, 0L, 0L, 0L);
+				}
+			}
+		}
+
+		@Test
+		public void 현재_년도2022에서_현재월8월보다_작성한내역_미래11월이_있을때는_11월부터_1월까지_내역을_보여준다() {
+			/**
+			 * given
+			 * 11월 지출: 4000, 수입: 3000
+			 * 10월 지출: 0, 수입: 0
+			 * 9월 지출: 0, 수입: 0
+			 * 08월 지출: 2000, 수입: 0
+			 * 07월 지출: 2000, 수입: 0
+			 * 06월 지출: 2000, 수입: 2000
+			 * 05월 지출: 2000, 수입: 2000
+			 * 04월 지출: 0, 수입: 2000
+			 * 03월 지출: 0, 수입: 2000
+			 * 02월 지출: 0, 수입: 0
+			 * 01월 지출: 0, 수입: 0
+			 */
+			createExpenditures(4, currentYear, 11);
+			createIncomes(3, currentYear, 11);
+			createExpenditures(2, currentYear, 8);
+			createExpenditures(2, currentYear, 7);
+			createExpenditures(2, currentYear, 6);
+			createExpenditures(2, currentYear, 5);
+			createIncomes(2, currentYear, 6);
+			createIncomes(2, currentYear, 5);
+			createIncomes(2, currentYear, 4);
+			createIncomes(2, currentYear, 3);
+
+			//when
+			FindMonthAccountResponse monthAccount = accountBookQueryRepository.findMonthAccount(user.getId(),
+				new MonthCondition(now, currentYear));
+
+			List<MonthDetail> results = monthAccount.getResults();
+
+			for (int i = 11; i >= 1; i--) {
+				MonthDetail monthDetail = results.get(11 - i);
+
+				if (i == 11) {
+					checkMonthDetail(monthDetail, i, 4000L, 3000L, -1000L);
+				}
+
+				if (i == 8 || i == 7) {
+					checkMonthDetail(monthDetail, i, 2000L, 0L, -2000L);
+				}
+
+				if (i == 6 || i == 5) {
+					checkMonthDetail(monthDetail, i, 2000L, 2000L, 0L);
+				}
+
+				if (i == 4 && i <= 3) {
+					checkMonthDetail(monthDetail, i, 0L, 2000L, 2000L);
+				}
+
+				if (i <= 2 || i == 10 || i == 9) {
+					checkMonthDetail(monthDetail, i, 0L, 0L, 0L);
+				}
+			}
+		}
+
+		@Test
+		public void 현재_년도보다_과거년도를_조회할때는_12월에서_1월까지_모두보여준다() {
+			/**
+			 *	given
+			 * 12~8월, 4~1월은 지출과 수입 모두 0원
+			 * 7월 지출: 2000, 수입: 0
+			 * 6월 지출: 2000, 수입: 2000
+			 * 5월 지출: 2000, 수입: 2000
+			 */
+			createExpenditures(2, pastYear, 7);
+			createExpenditures(2, pastYear, 6);
+			createExpenditures(2, pastYear, 5);
+			createIncomes(2, pastYear, 6);
+			createIncomes(2, pastYear, 5);
+
+			//when
+			FindMonthAccountResponse monthAccount = accountBookQueryRepository.findMonthAccount(user.getId(),
+				new MonthCondition(now, pastYear));
+
+			List<MonthDetail> results = monthAccount.getResults();
+
+			for (int i = 12; i >= 1; i--) {
+				MonthDetail monthDetail = results.get(12 - i);
+
+				if (i == 7) {
+					checkMonthDetail(monthDetail, i, 2000L, 0L, -2000L);
+					continue;
+				}
+
+				if (i == 6 || i == 5) {
+					checkMonthDetail(monthDetail, i, 2000L, 2000L, 0L);
+					continue;
+				}
+
+				checkMonthDetail(monthDetail, i, 0L, 0L, 0L);
+			}
+
+		}
+
+		@Test
+		public void 현재_년도보다_미래년도를_조회할때는_작성한_월만_보여준다() {
+			/**
+			 *	given
+			 * 7월 지출: 2000, 수입: 0
+			 * 6월 지출: 2000, 수입: 2000
+			 * 5월 지출: 2000, 수입: 2000
+			 */
+			createExpenditures(2, futureYear, 7);
+			createExpenditures(2, futureYear, 6);
+			createExpenditures(2, futureYear, 5);
+			createIncomes(2, futureYear, 6);
+			createIncomes(2, futureYear, 5);
+
+			//when
+			FindMonthAccountResponse monthAccount = accountBookQueryRepository.findMonthAccount(user.getId(),
+				new MonthCondition(now, futureYear));
+
+			List<MonthDetail> results = monthAccount.getResults();
+
+			for (int i = 7; i >= 5; i--) {
+				MonthDetail monthDetail = results.get(7 - i);
+
+				if (i == 7) {
+					checkMonthDetail(monthDetail, i, 2000L, 0L, -2000L);
+					continue;
+				}
+
+				checkMonthDetail(monthDetail, i, 2000L, 2000L, 0L);
+			}
+		}
+	}
+
+	private void createExpenditures(int count, int year, int month) {
 		for (int i = 0; i < count; i++) {
 			expenditureRepository.save(new Expenditure(
-				LocalDateTime.of(2022, 8, 1 + i * 2, 0, 0),
+				LocalDateTime.of(year, month, 1 + i * 2, 0, 0),
 				1000L,
 				"지출" + i,
 				expenditureCategory.getName(),
@@ -235,10 +426,10 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 		}
 	}
 
-	private void createIncomes(int count) {
+	private void createIncomes(int count, int year, int month) {
 		for (int i = 0; i < count; i++) {
 			incomeRepository.save(new Income(
-				LocalDateTime.of(2022, 8, 11 + i * 2, 0, 0),
+				LocalDateTime.of(year, month, 11 + i * 2, 0, 0),
 				1000L,
 				"수입" + i,
 				incomeCategory.getName(),
@@ -247,5 +438,14 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 			));
 		}
 	}
+
+	private void checkMonthDetail(MonthDetail monthDetail, int targetMonth, Long targetExpenditure, Long targetIncome,
+		Long targetTotal) {
+		assertThat(monthDetail.getMonth()).isEqualTo(targetMonth);
+		assertThat(monthDetail.getIncomeSum()).isEqualTo(targetIncome);
+		assertThat(monthDetail.getExpenditureSum()).isEqualTo(targetExpenditure);
+		assertThat(monthDetail.getTotalSum()).isEqualTo(targetTotal);
+	}
+
 }
 


### PR DESCRIPTION
## 개요

- 월별 상세 내역 + 연간 합계 내역 api 작성

## 정책 

연간합계 내역은 정책이 간단합니다. 
요청받은 년도로 groupBy 한 후 지출 총합과 수입 총합을 구하면 됩니다.

월간 상세 내역의 정책이 조금 복잡합니다.
현재를 `2022년도 08월 12일`로 기준을 잡겠습니다.

<img width="221" alt="Screen Shot 2022-08-07 at 20 17 42" src="https://user-images.githubusercontent.com/52152200/183288248-6074ea3c-c409-4ba7-a0ec-cfcaec665eab.png">

- 과거

2022년보다 과거 년도(2021년도)를 조회할 경우
사용자가 작성하든 하지 않았든 12월 ~ 1월의 데이터를 모두 보여주어야합니다(0원으로)

- 현재 

현재는 두 가지 케이스가 있습니다.

2022년도 07월까지 작성한 경우는
현재 월 08월부터  01월까지 모두 보여주어야합니다.

2022년도 11월(미래)에 작성이 되어있는 경우는
미래 11월부터 1월까지 모두 보여주어야 합니다.

- 미래

미래는 사용자가 작성하지 않은 부분은 보여주지 않습니다.
예를들어 7,6,5월만 작성하였고, 이전에는 작성되지 않은 1,2,3,4월도 0원으로 데이터 표시해주었던 것이
이제는 7,6,5월만 보여줍니다

## 개략적 로직

income과 expenditure를 (month, sum)groupby로 가져옵니다.


위의 정책에 따라 어디까지 month를 보여줄지 판단합니다.
대부분의 조건에 대한 책임은 monthCondition이 지고 있습니다.

