### PR TITLE
[#148] access token 만료 시간 버그 수정

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/config/JwtConfigure.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/JwtConfigure.java
@@ -14,6 +14,6 @@ public class JwtConfigure {
 	private String header;
 	private String issuer;
 	private String clientSecret;
-	private int expirySeconds;
-	private int refreshExpirySeconds;
+	private int expirySecondsMillis;
+	private int refreshExpirySecondsMillis;
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/Jwt.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/Jwt.java
@@ -34,8 +34,8 @@ public final class Jwt {
 		this.jwtConfigure = jwtConfigure;
 		this.issuer = jwtConfigure.getIssuer();
 		this.clientSecret = jwtConfigure.getClientSecret();
-		this.expirySeconds = jwtConfigure.getExpirySeconds();
-		this.refreshExpirySeconds = jwtConfigure.getRefreshExpirySeconds();
+		this.expirySeconds = jwtConfigure.getExpirySecondsMillis();
+		this.refreshExpirySeconds = jwtConfigure.getRefreshExpirySecondsMillis();
 		this.algorithm = Algorithm.HMAC512(clientSecret);
 		this.jwtVerifier = com.auth0.jwt.JWT.require(algorithm)
 			.withIssuer(issuer)

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/service/TokenProvider.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/service/TokenProvider.java
@@ -25,7 +25,7 @@ public class TokenProvider {
 		builder.withIssuer(jwt.getIssuer());
 		builder.withIssuedAt(now);
 		if (jwt.getExpirySeconds() > 0) {
-			builder.withExpiresAt(new Date(now.getTime() + jwt.getExpirySeconds() * 1000L));
+			builder.withExpiresAt(new Date(now.getTime() + jwt.getExpirySeconds()));
 		}
 		builder.withClaim("userId", userId)
 			.withClaim("email", email);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,5 +29,5 @@ jwt:
   header: Authorization
   issuer: tenwonmoa
   client-secret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
-  expiry-seconds: 3600000 # 1시간 = 3,600,000ms
-  refresh-expiry-seconds: 1209600000 # 2주 = 1000ms * 60 * 60 * 24 * 14
+  expiry-seconds-millis: 3600000 # 1시간 = 3,600,000ms
+  refresh-expiry-seconds-millis: 1209600000 # 2주 = 1000ms * 60 * 60 * 24 * 14

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/security/jwt/JwtTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/security/jwt/JwtTest.java
@@ -27,8 +27,8 @@ class JwtTest {
 		assertAll(
 			() -> assertThat(jwtConfigure.getHeader()).isEqualTo("testToken"),
 			() -> assertThat(jwtConfigure.getIssuer()).isEqualTo("testIssuer"),
-			() -> assertThat(jwtConfigure.getExpirySeconds()).isEqualTo(6000),
-			() -> assertThat(jwtConfigure.getRefreshExpirySeconds()).isEqualTo(600000)
+			() -> assertThat(jwtConfigure.getExpirySecondsMillis()).isEqualTo(6000),
+			() -> assertThat(jwtConfigure.getRefreshExpirySecondsMillis()).isEqualTo(600000)
 		);
 	}
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,5 +26,5 @@ jwt:
   header: testToken
   issuer: testIssuer
   client-secret: lsuvomkeoiotkbzdjrejfgdsfngusviykzsvjoriyukscpmxiijmpfsdwveljsml
-  expiry-seconds: 100
-  refresh-expiry-seconds: 10000
+  expiry-seconds-millis: 3600000
+  refresh-expiry-seconds-millis: 1209600000

--- a/src/test/resources/jwt-config-test.properties
+++ b/src/test/resources/jwt-config-test.properties
@@ -1,5 +1,5 @@
 jwt.header=testToken
 jwt.issuer=testIssuer
 jwt.client-secret=lsuvomkeoiotkbzdjrejfgdsfngusviykzsvjoriyukscpmxiijmpfsdwveljsml
-jwt.expiry-seconds=6000
-jwt.refresh-expiry-seconds=600000
+jwt.expiry-seconds-millis=6000
+jwt.refresh-expiry-seconds-millis=600000


### PR DESCRIPTION
## 문제
- 현재 access-token 만료 시간에 1,000 시간으로 설정이 돼 있다.
- 아래 사진을 보면 이미 ms를 계산해 1시간으로 설정해 놓음
![image](https://user-images.githubusercontent.com/43159295/183299102-d6c87225-8063-47ca-89e3-29fc0c6529d3.png)

## 변경 전
- 이미 ms를 계산해서 설정핸 놨지만 토큰 생성시에 1000L을 곱하여 1000시간으로 설정이 됨
![image](https://user-images.githubusercontent.com/43159295/183299192-7cc42111-3e30-4ac3-9ef6-8912c5b2bc87.png)

## 변경 후
- *1000 제거
![image](https://user-images.githubusercontent.com/43159295/183299229-4aa45f3f-5e73-4652-b4f4-84fa6b424d77.png)

- 모든 yml 파일에 expiry-seconds에 millis를 붙여 헷갈리지 않게 의미를 부여
![image](https://user-images.githubusercontent.com/43159295/183347976-f66c1863-7b88-428c-a27a-0b91ca3616fd.png)
