### PR TITLE
[#147] 지출에서 수입으로 수정할 수 있다

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/Expenditure.java
@@ -19,6 +19,7 @@ import javax.persistence.Table;
 
 import com.prgrms.tenwonmoa.domain.accountbook.dto.expenditure.UpdateExpenditureRequest;
 import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.CategoryType;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.common.BaseEntity;
 import com.prgrms.tenwonmoa.domain.user.User;
@@ -69,6 +70,14 @@ public class Expenditure extends BaseEntity {
 		this.categoryName = categoryName;
 		this.user = user;
 		this.userCategory = userCategory;
+	}
+
+	public void validateOwner(Long authId) {
+		this.user.validateLoginUser(authId);
+	}
+
+	public CategoryType getCategoryType() {
+		return this.userCategory.getCategoryType();
 	}
 
 	public void update(UserCategory userCategory, UpdateExpenditureRequest request) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/expenditure/UpdateExpenditureRequest.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/expenditure/UpdateExpenditureRequest.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
 
@@ -36,8 +36,8 @@ public class UpdateExpenditureRequest {
 		this.userCategoryId = userCategoryId;
 	}
 
-	public Expenditure toEntity(User user, UserCategory userCategory, String categoryName) {
-		return new Expenditure(
+	public Income toEntity(User user, UserCategory userCategory, String categoryName) {
+		return new Income(
 			this.registerDate,
 			this.amount,
 			this.content,

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/CategoryType.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/CategoryType.java
@@ -6,4 +6,8 @@ public enum CategoryType {
 	public static boolean isExpenditure(CategoryType type) {
 		return type == EXPENDITURE;
 	}
+
+	public static boolean isIncome(CategoryType type) {
+		return type == INCOME;
+	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/UserCategory.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/UserCategory.java
@@ -46,6 +46,10 @@ public class UserCategory extends BaseEntity {
 		return this.category.getCategoryType().name();
 	}
 
+	public CategoryType getCategoryType() {
+		return this.category.getCategoryType();
+	}
+
 	public void updateCategoryAsNull() {
 		this.category = null;
 	}


### PR DESCRIPTION
## 변경사항

- expenditure 안에서 parameter authenticationId 받아서 사용자 검증

> expenditure.validateOwner(Long authenticationId)

- expenditure 안에서 내부 인스턴스 userCategory 이용해서 Category의 CategoryType 가져오기

> 실제 객체가 의존을 맺고 있는 객체에 대해서만 참조하도록 이용했음  
> expenditure.getCatgoryType()

- UpdateExpenditureRequest에서 toEntity를 toIncome으로 변경

> updateRequest에서 expenditure를 만들 일이 없다.

## 추가기능

CategoryType을 이용해서 지출을 수입으로도 변경하도록 하였다.
