### PR TITLE
[#153] 지출 등록과 조회 Docs 테스트 진행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.00
+                minimum = 0.80
             }
 
             excludes = [

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/expenditure/CreateExpenditureRequest.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/expenditure/CreateExpenditureRequest.java
@@ -11,11 +11,15 @@ import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
 
+import lombok.Getter;
+
+@Getter
 public class CreateExpenditureRequest {
 
 	@NotNull(message = "등록일을 채워주세요")
 	private final LocalDateTime registerDate;
 
+	@NotNull
 	@Min(value = 0L, message = "최소값은 0입니다")
 	@Max(value = 1_000_000_000_000L, message = "최대값은 1조입니다")
 	private final Long amount;

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/expenditure/CreateExpenditureResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/expenditure/CreateExpenditureResponse.java
@@ -9,7 +9,7 @@ public class CreateExpenditureResponse {
 
 	private final Long id;
 
-	private CreateExpenditureResponse(Long id) {
+	public CreateExpenditureResponse(Long id) {
 		this.id = id;
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/expenditure/FindExpenditureResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/expenditure/FindExpenditureResponse.java
@@ -21,7 +21,7 @@ public class FindExpenditureResponse {
 
 	private final String categoryName;
 
-	private FindExpenditureResponse(
+	public FindExpenditureResponse(
 		Long id,
 		LocalDateTime registerDate,
 		Long amount,

--- a/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/handler/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.prgrms.tenwonmoa.exception.handler;
 
+import static com.prgrms.tenwonmoa.exception.message.Message.*;
 import static org.springframework.http.HttpStatus.*;
 
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -42,6 +44,18 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleClientBadRequest(RuntimeException exception) {
 		log.info(exception.getMessage(), exception);
 		ErrorResponse errorResponse = new ErrorResponse(List.of(exception.getMessage()), BAD_REQUEST.value());
+		return ResponseEntity
+			.status(BAD_REQUEST.value())
+			.body(errorResponse);
+	}
+
+	// 400 : Wrong Date Format - 잘못된 날짜 포맷 요청
+	// Client의 잘못된 요청으로 인한 에러 처리
+	@ExceptionHandler(DateTimeParseException.class)
+	public ResponseEntity<ErrorResponse> handleClientBadTimeFormatRequest(RuntimeException exception) {
+		log.info(exception.getMessage(), exception);
+		ErrorResponse errorResponse = new ErrorResponse(List.of(WRONG_DATE_TIME_FORMAT.getMessage()),
+			BAD_REQUEST.value());
 		return ResponseEntity
 			.status(BAD_REQUEST.value())
 			.body(errorResponse);

--- a/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 @Getter
 public enum Message {
 
+	WRONG_DATE_TIME_FORMAT("잘못된 날짜 양식으로 요청하였습니다"),
+
 	NO_AUTHENTICATION("권한이 없습니다."),
 
 	// 사용자

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -7,6 +7,81 @@ servers:
 - url: http://3.39.184.232:8080
 tags: []
 paths:
+  /api/v1/expenditures:
+    post:
+      tags:
+      - api
+      operationId: expenditure-
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/api-v1-expenditures1023026241'
+            examples:
+              expenditure-create-forbidden:
+                value: "{\"registerDate\":\"2022-08-12T08:11:00\",\"amount\":1000,\"\
+                  content\":\"식비\",\"userCategoryId\":2}"
+              expenditure-post-amount-max-error:
+                value: "{\"registerDate\":\"2022-08-12T08:11:00\",\"amount\":1000000000001,\"\
+                  content\":\"식비\",\"userCategoryId\":2}"
+              expenditure-post-register-date-null:
+                value: "{\"registerDate\":null,\"amount\":1000,\"content\":\"식비\"\
+                  ,\"userCategoryId\":2}"
+              expenditure-post-amount-null:
+                value: "{\"registerDate\":\"2022-08-12T08:11:00\",\"amount\":null,\"\
+                  content\":\"식비\",\"userCategoryId\":2}"
+              expenditure-post-user-category-id-null:
+                value: "{\"registerDate\":\"2022-08-12T08:11:00\",\"amount\":1000000000001,\"\
+                  content\":\"식비\",\"userCategoryId\":null}"
+              expenditure-post-content-max-error:
+                value: "{\"registerDate\":\"2022-08-12T08:11:00\",\"amount\":1000,\"\
+                  content\":\"이것은50글자를넘습니다.이것은50글자를넘습니다.이것은50글자를넘습니다.이것은50글자를넘습니다\
+                  .\",\"userCategoryId\":2}"
+              expenditure-create:
+                value: "{\"registerDate\":\"2022-08-12T08:11:00\",\"amount\":1000,\"\
+                  content\":\"식비\",\"userCategoryId\":2}"
+              expenditure-post-amount-min-error:
+                value: "{\"registerDate\":\"2022-08-12T08:11:00\",\"amount\":-1,\"\
+                  content\":\"식비\",\"userCategoryId\":2}"
+      responses:
+        "403":
+          description: "403"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
+              examples:
+                expenditure-create-forbidden:
+                  value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
+        "400":
+          description: "400"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
+              examples:
+                expenditure-post-amount-max-error:
+                  value: "{\"messages\":[\"최대값은 1조입니다\"],\"status\":400}"
+                expenditure-post-register-date-null:
+                  value: "{\"messages\":[\"등록일을 채워주세요\"],\"status\":400}"
+                expenditure-post-amount-null:
+                  value: "{\"messages\":[\"must not be null\"],\"status\":400}"
+                expenditure-post-user-category-id-null:
+                  value: "{\"messages\":[\"최대값은 1조입니다\",\"유저 카테고리 아이디를 채워주세요\"],\"\
+                    status\":400}"
+                expenditure-post-content-max-error:
+                  value: "{\"messages\":[\"내용의 최대 길이는 50입니다\"],\"status\":400}"
+                expenditure-post-amount-min-error:
+                  value: "{\"messages\":[\"최소값은 0입니다\"],\"status\":400}"
+        "201":
+          description: "201"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-expenditures780147897'
+              examples:
+                expenditure-create:
+                  value: "{\"id\":1}"
   /api/v1/statistics:
     get:
       tags:
@@ -36,6 +111,124 @@ paths:
                     :\"교통/차량\",\"total\":45,\"percent\":34.09},{\"name\":\"문화생활\"\
                     ,\"total\":44,\"percent\":33.33},{\"name\":\"마트/편의점\",\"total\"\
                     :43,\"percent\":32.58}]}"
+  /api/v1/account-book/search:
+    get:
+      tags:
+      - api
+      operationId: search-account-book
+      parameters:
+      - name: categories
+        in: query
+        description: 유저카테고리 아이디
+        required: true
+        schema:
+          type: string
+      - name: minprice
+        in: query
+        description: 최소 가격
+        required: true
+        schema:
+          type: string
+      - name: maxprice
+        in: query
+        description: 최대 가격
+        required: true
+        schema:
+          type: string
+      - name: start
+        in: query
+        description: 시작 등록일
+        required: true
+        schema:
+          type: string
+      - name: end
+        in: query
+        description: 종료 등록일
+        required: true
+        schema:
+          type: string
+      - name: content
+        in: query
+        description: "지출, 수입의 내용"
+        required: true
+        schema:
+          type: string
+      - name: size
+        in: query
+        description: 페이지의 사이즈
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: 페이지 번호
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-account-book-search-1060074379'
+              examples:
+                search-account-book:
+                  value: |-
+                    {
+                      "results" : [ {
+                        "registerDate" : "2022-08-09",
+                        "amount" : 10000,
+                        "content" : "점심",
+                        "id" : 1,
+                        "type" : "EXPENDITURE",
+                        "categoryName" : "식비"
+                      }, {
+                        "registerDate" : "2022-08-09",
+                        "amount" : 50000,
+                        "content" : "용돈",
+                        "id" : 1,
+                        "type" : "INCOME",
+                        "categoryName" : "용돈"
+                      } ],
+                      "currentPage" : 1,
+                      "nextPage" : 2,
+                      "incomeSum" : 50000,
+                      "expenditureSum" : 10000
+                    }
+  /api/v1/expenditures/{expenditureId}:
+    get:
+      tags:
+      - api
+      operationId: expenditure-get
+      parameters:
+      - name: expenditureId
+        in: path
+        description: ""
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: "400"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-incomes--940438351'
+              examples:
+                expenditure-get-forbidden:
+                  value: "{\"messages\":[\"해당 지출이 존재 하지 않습니다.\"],\"status\":400}"
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-expenditures-expenditureId2033270015'
+              examples:
+                expenditure-get:
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-09T06:30:37.238187\"\
+                    ,\"amount\":20000,\"content\":\"돈까스마시써\",\"userCategoryId\":3,\"\
+                    categoryName\":\"식비\"}"
   /api/v1/incomes/:
     post:
       tags:
@@ -48,10 +241,10 @@ paths:
               $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-create:
-                value: "{\"registerDate\":\"2022-08-07T01:25:20.769897\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-09T06:30:44.830866\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-create-fail:
-                value: "{\"registerDate\":\"2022-08-07T01:25:20.802016\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-09T06:30:44.936218\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "201":
@@ -102,7 +295,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-incomes-incomeId-1674408626'
               examples:
                 income-find-by-id:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-07T01:25:20.819858\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-09T06:30:44.994408\"\
                     ,\"amount\":1000,\"content\":\"content\",\"userCategoryId\":1,\"\
                     categoryName\":\"용돈\"}"
         "403":
@@ -132,10 +325,10 @@ paths:
               $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-update:
-                value: "{\"registerDate\":\"2022-08-07T01:25:19.84052\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-09T06:30:42.47984\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
               income-update-fail:
-                value: "{\"registerDate\":\"2022-08-07T01:25:20.737036\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-09T06:30:44.733222\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
       responses:
         "204":
@@ -225,6 +418,45 @@ components:
         expenditureTotalSum:
           type: number
           description: 지출 총 합계
+    api-v1-account-book-search-1060074379:
+      type: object
+      properties:
+        nextPage:
+          type: number
+          description: 다음 페이지
+        incomeSum:
+          type: number
+          description: 수입의 총합
+        currentPage:
+          type: number
+          description: 현재 페이지
+        results:
+          type: array
+          description: "검색된 지출, 수입 데이터"
+          items:
+            type: object
+            properties:
+              amount:
+                type: number
+                description: 금액
+              id:
+                type: number
+                description: 지출 or 수입의 아이디
+              type:
+                type: string
+                description: 지출 or 수입 종류
+              categoryName:
+                type: string
+                description: 카테고리 이름
+              content:
+                type: string
+                description: 내용
+              registerDate:
+                type: string
+                description: 등록일
+        expenditureSum:
+          type: number
+          description: 지출의 총합
     api-v1-incomes-1988379506:
       type: object
       properties:
@@ -246,6 +478,27 @@ components:
         id:
           type: number
           description: 생성된 수입 아이디
+    api-v1-expenditures780147897:
+      type: object
+      properties:
+        id:
+          type: number
+          description: 생성된 지출 아이디
+    api-v1-expenditures1023026241:
+      type: object
+      properties:
+        amount:
+          type: number
+          description: 금액
+        userCategoryId:
+          type: number
+          description: 유저카테고리 아이디
+        content:
+          type: string
+          description: 내용
+        registerDate:
+          type: string
+          description: 지출 등록 날짜
     api-v1-incomes-incomeId-1674408626:
       type: object
       properties:
@@ -267,3 +520,24 @@ components:
         registerDate:
           type: string
           description: 수입 등록 날짜
+    api-v1-expenditures-expenditureId2033270015:
+      type: object
+      properties:
+        amount:
+          type: number
+          description: 지출 금액
+        userCategoryId:
+          type: number
+          description: 유저 카테고리 ID
+        id:
+          type: number
+          description: 지출 ID
+        categoryName:
+          type: string
+          description: 카테고리 이름
+        content:
+          type: string
+          description: 내용
+        registerDate:
+          type: string
+          description: 지출 등록 날짜

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -14,7 +14,7 @@ paths:
       operationId: expenditure-
       requestBody:
         content:
-          application/json:
+          application/json;charset=UTF-8:
             schema:
               $ref: '#/components/schemas/api-v1-expenditures1023026241'
             examples:
@@ -67,7 +67,7 @@ paths:
                 expenditure-post-amount-null:
                   value: "{\"messages\":[\"must not be null\"],\"status\":400}"
                 expenditure-post-user-category-id-null:
-                  value: "{\"messages\":[\"최대값은 1조입니다\",\"유저 카테고리 아이디를 채워주세요\"],\"\
+                  value: "{\"messages\":[\"유저 카테고리 아이디를 채워주세요\",\"최대값은 1조입니다\"],\"\
                     status\":400}"
                 expenditure-post-content-max-error:
                   value: "{\"messages\":[\"내용의 최대 길이는 50입니다\"],\"status\":400}"
@@ -226,7 +226,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-expenditures-expenditureId2033270015'
               examples:
                 expenditure-get:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-09T06:30:37.238187\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-09T06:51:11.361812\"\
                     ,\"amount\":20000,\"content\":\"돈까스마시써\",\"userCategoryId\":3,\"\
                     categoryName\":\"식비\"}"
   /api/v1/incomes/:
@@ -241,10 +241,10 @@ paths:
               $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-create:
-                value: "{\"registerDate\":\"2022-08-09T06:30:44.830866\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-09T06:51:18.823947\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-create-fail:
-                value: "{\"registerDate\":\"2022-08-09T06:30:44.936218\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-09T06:51:18.965266\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "201":
@@ -295,7 +295,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-incomes-incomeId-1674408626'
               examples:
                 income-find-by-id:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-09T06:30:44.994408\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-09T06:51:19.023668\"\
                     ,\"amount\":1000,\"content\":\"content\",\"userCategoryId\":1,\"\
                     categoryName\":\"용돈\"}"
         "403":
@@ -325,10 +325,10 @@ paths:
               $ref: '#/components/schemas/api-v1-incomes-1988379506'
             examples:
               income-update:
-                value: "{\"registerDate\":\"2022-08-09T06:30:42.47984\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-09T06:51:16.328775\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
               income-update-fail:
-                value: "{\"registerDate\":\"2022-08-09T06:30:44.733222\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-09T06:51:18.726127\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
       responses:
         "204":

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/ExpenditureDocsTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/ExpenditureDocsTest.java
@@ -1,4 +1,344 @@
 package com.prgrms.tenwonmoa.domain.accountbook.controller.docs;
 
+import static com.prgrms.tenwonmoa.exception.message.Message.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
+import com.prgrms.tenwonmoa.common.documentdto.ErrorResponseDoc;
+import com.prgrms.tenwonmoa.domain.accountbook.controller.ExpenditureController;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.expenditure.CreateExpenditureRequest;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.expenditure.CreateExpenditureResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.expenditure.FindExpenditureResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.service.ExpenditureService;
+import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
+import com.prgrms.tenwonmoa.exception.UnauthorizedUserException;
+
+@WebMvcTest(controllers = ExpenditureController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+@MockBean(JpaMetamodelMappingContext.class)
+@DisplayName("지출 DOCS 테스트: ")
 public class ExpenditureDocsTest {
+
+	private static final String BASE_URL = "/api/v1/expenditures";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private JwtAuthenticationFilter jwtAuthenticationFilter;    // 테스트 실행을 위해 필요
+
+	@MockBean
+	private ExpenditureService expenditureService;
+
+	private final Long authId = 1L;
+
+	private final Long noAuthId = 2L;
+
+	private static final Long MAX_AMOUNT = 1000000000000L;
+
+	private static final String MAX_CONTENT = "이것은50글자를넘습니다.이것은50글자를넘습니다.이것은50글자를넘습니다.이것은50글자를넘습니다.";
+
+	@Nested
+	@DisplayName("지출 등록 API 호출 중 ")
+	class DescribeOfPostExpenditure {
+
+		private final LocalDateTime registerDate = LocalDateTime.of(2022, 8, 12, 8, 11);
+
+		private final Long amount = 1000L;
+
+		private final String content = "식비";
+
+		private final Long userCategoryId = 2L;
+
+		private final CreateExpenditureRequest request = new CreateExpenditureRequest(
+			registerDate,
+			amount,
+			content,
+			userCategoryId
+		);
+
+		private final Long createdId = 1L;
+
+		CreateExpenditureResponse response = new CreateExpenditureResponse(1L);
+
+		@Test
+		@WithMockCustomUser
+		public void 등록일자가_null일경우_400() throws Exception {
+			CreateExpenditureRequest wrongResult = new CreateExpenditureRequest(
+				null,
+				amount,
+				content,
+				userCategoryId
+			);
+
+			mockMvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(wrongResult))
+				)
+				.andExpect(status().isBadRequest())
+				.andDo(document("expenditure-post-register-date-null",
+					responseFields(
+						ErrorResponseDoc.fieldDescriptors()
+					)
+				));
+		}
+
+		@Test
+		@WithMockCustomUser
+		public void 금액이_null일경우_400() throws Exception {
+			CreateExpenditureRequest wrongResult = new CreateExpenditureRequest(
+				registerDate,
+				null,
+				content,
+				userCategoryId
+			);
+
+			mockMvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(wrongResult))
+				)
+				.andExpect(status().isBadRequest())
+				.andDo(document("expenditure-post-amount-null",
+					responseFields(
+						ErrorResponseDoc.fieldDescriptors()
+					)
+				));
+		}
+
+		@Test
+		@WithMockCustomUser
+		public void 금액의_범위가_0원보다_작을경우_400() throws Exception {
+
+			CreateExpenditureRequest wrongResult = new CreateExpenditureRequest(
+				registerDate,
+				-1L,
+				content,
+				userCategoryId
+			);
+
+			mockMvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(wrongResult))
+				)
+				.andExpect(status().isBadRequest())
+				.andDo(document("expenditure-post-amount-min-error",
+					responseFields(
+						ErrorResponseDoc.fieldDescriptors()
+					)
+				));
+		}
+
+		@Test
+		@WithMockCustomUser
+		public void 금액의_범위가_1조보다_클경우_400() throws Exception {
+
+			CreateExpenditureRequest wrongResult = new CreateExpenditureRequest(
+				registerDate,
+				MAX_AMOUNT + 1,
+				content,
+				userCategoryId
+			);
+
+			mockMvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(wrongResult))
+				)
+				.andExpect(status().isBadRequest())
+				.andDo(document("expenditure-post-amount-max-error",
+					responseFields(
+						ErrorResponseDoc.fieldDescriptors()
+					)
+				));
+		}
+
+		@Test
+		@WithMockCustomUser
+		public void 내용의길이가_50을넘길경우_400() throws Exception {
+			CreateExpenditureRequest wrongResult = new CreateExpenditureRequest(
+				registerDate,
+				amount,
+				MAX_CONTENT,
+				userCategoryId
+			);
+
+			mockMvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(wrongResult))
+				)
+				.andExpect(status().isBadRequest())
+				.andDo(document("expenditure-post-content-max-error",
+					responseFields(
+						ErrorResponseDoc.fieldDescriptors()
+					)
+				));
+
+		}
+
+		@Test
+		@WithMockCustomUser
+		public void 유저카테고리아이디가_null일경우_400() throws Exception {
+			CreateExpenditureRequest wrongResult = new CreateExpenditureRequest(
+				registerDate,
+				MAX_AMOUNT + 1,
+				content,
+				null
+			);
+
+			mockMvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(wrongResult))
+				)
+				.andExpect(status().isBadRequest())
+				.andDo(document("expenditure-post-user-category-id-null",
+					responseFields(
+						ErrorResponseDoc.fieldDescriptors()
+					)
+				));
+		}
+
+		@Test
+		@WithMockCustomUser
+		public void 인증받지않은_사용자일경우_403() throws Exception {
+			given(expenditureService.createExpenditure(any(), any(CreateExpenditureRequest.class)))
+				.willThrow(new UnauthorizedUserException(NO_AUTHENTICATION.getMessage()));
+
+			mockMvc.perform(post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+				)
+				.andExpect(status().isForbidden())
+				.andDo(document("expenditure-create-forbidden",
+					responseFields(
+						ErrorResponseDoc.fieldDescriptors()
+					)
+				));
+		}
+
+		@Test
+		@WithMockCustomUser
+		public void 성공적으로_지출을_생성_할_수_있다_201() throws Exception {
+			given(expenditureService.createExpenditure(anyLong(), any(CreateExpenditureRequest.class)))
+				.willReturn(response);
+
+			mockMvc.perform(post(BASE_URL)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+			).andDo(document("expenditure-create",
+				requestFields(documentCreateExpenditureRequest()),
+				responseFields(documentCreateExpenditureResponse())
+			));
+		}
+
+		private List<FieldDescriptor> documentCreateExpenditureRequest() {
+			return List.of(
+				fieldWithPath("registerDate").type(STRING).description("지출 등록 날짜"),
+				fieldWithPath("amount").type(NUMBER).description("금액"),
+				fieldWithPath("content").type(STRING).description("내용"),
+				fieldWithPath("userCategoryId").type(NUMBER).description("유저카테고리 아이디")
+			);
+		}
+
+		private List<FieldDescriptor> documentCreateExpenditureResponse() {
+			return List.of(fieldWithPath("id").type(NUMBER).description("생성된 지출 아이디"));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("지출 상세 내역 API 호출 중")
+	class DescribeOfGetExpenditure {
+
+		private final Long expenditureId = 1L;
+
+		private final FindExpenditureResponse response = new FindExpenditureResponse(
+			1L,
+			LocalDateTime.now(),
+			20000L,
+			"돈까스마시써",
+			3L,
+			"식비"
+		);
+
+		@Test
+		@WithMockCustomUser
+		public void 권한이없는_사용자일경우_403() throws Exception {
+			given(expenditureService.findExpenditure(any(Long.class), any()))
+				.willThrow(new UnauthorizedUserException(NO_AUTHENTICATION.getMessage()));
+
+			mockMvc.perform(get(BASE_URL + "/{expenditureId}", expenditureId))
+				.andExpect(status().isForbidden())
+				.andDo(document("expenditure-get-forbidden",
+					responseFields(
+						ErrorResponseDoc.fieldDescriptors()
+					)));
+		}
+
+		@Test
+		@WithMockCustomUser
+		public void 없는_지출일경우_400() throws Exception {
+			given(expenditureService.findExpenditure(any(Long.class), any()))
+				.willThrow(new NoSuchElementException(EXPENDITURE_NOT_FOUND.getMessage()));
+
+			mockMvc.perform(get(BASE_URL + "/{expenditureId}", expenditureId))
+				.andExpect(status().isBadRequest())
+				.andDo(document("expenditure-get-forbidden",
+					responseFields(
+						ErrorResponseDoc.fieldDescriptors()
+					)));
+		}
+
+		@Test
+		@WithMockCustomUser
+		public void 성공적으로_지출을_조회할_수_있다_200() throws Exception {
+			given(expenditureService.findExpenditure(any(Long.class), any()))
+				.willReturn(response);
+
+			mockMvc.perform(get(BASE_URL + "/{expenditureId}", expenditureId))
+				.andExpect(status().isOk())
+				.andDo(document("expenditure-get",
+					responseFields(
+						documentFindExpenditureResponse()
+					)));
+		}
+
+		private List<FieldDescriptor> documentFindExpenditureResponse() {
+			return List.of(
+				fieldWithPath("id").type(NUMBER).description("지출 ID"),
+				fieldWithPath("registerDate").type(STRING).description("지출 등록 날짜"),
+				fieldWithPath("amount").type(NUMBER).description("지출 금액"),
+				fieldWithPath("content").type(STRING).description("내용"),
+				fieldWithPath("userCategoryId").type(NUMBER).description("유저 카테고리 ID"),
+				fieldWithPath("categoryName").type(STRING).description("카테고리 이름")
+			);
+		}
+
+	}
+
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/ExpenditureDocsTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/ExpenditureDocsTest.java
@@ -1,8 +1,8 @@
 package com.prgrms.tenwonmoa.domain.accountbook.controller.docs;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.prgrms.tenwonmoa.exception.message.Message.*;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/ExpenditureDocsTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/ExpenditureDocsTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
@@ -17,9 +18,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
@@ -28,6 +30,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
 import com.prgrms.tenwonmoa.common.documentdto.ErrorResponseDoc;
+import com.prgrms.tenwonmoa.config.JwtConfigure;
+import com.prgrms.tenwonmoa.config.WebSecurityConfig;
 import com.prgrms.tenwonmoa.domain.accountbook.controller.ExpenditureController;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.expenditure.CreateExpenditureRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.expenditure.CreateExpenditureResponse;
@@ -36,8 +40,13 @@ import com.prgrms.tenwonmoa.domain.accountbook.service.ExpenditureService;
 import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
 import com.prgrms.tenwonmoa.exception.UnauthorizedUserException;
 
-@WebMvcTest(controllers = ExpenditureController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(controllers = ExpenditureController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtConfigure.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+	}
+)
 @AutoConfigureRestDocs
 @MockBean(JpaMetamodelMappingContext.class)
 @DisplayName("지출 DOCS 테스트: ")
@@ -52,14 +61,7 @@ public class ExpenditureDocsTest {
 	private ObjectMapper objectMapper;
 
 	@MockBean
-	private JwtAuthenticationFilter jwtAuthenticationFilter;    // 테스트 실행을 위해 필요
-
-	@MockBean
 	private ExpenditureService expenditureService;
-
-	private final Long authId = 1L;
-
-	private final Long noAuthId = 2L;
 
 	private static final Long MAX_AMOUNT = 1000000000000L;
 
@@ -101,6 +103,7 @@ public class ExpenditureDocsTest {
 			mockMvc.perform(post(BASE_URL)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(wrongResult))
+					.with(csrf())
 				)
 				.andExpect(status().isBadRequest())
 				.andDo(document("expenditure-post-register-date-null",
@@ -123,6 +126,7 @@ public class ExpenditureDocsTest {
 			mockMvc.perform(post(BASE_URL)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(wrongResult))
+					.with(csrf())
 				)
 				.andExpect(status().isBadRequest())
 				.andDo(document("expenditure-post-amount-null",
@@ -146,6 +150,7 @@ public class ExpenditureDocsTest {
 			mockMvc.perform(post(BASE_URL)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(wrongResult))
+					.with(csrf())
 				)
 				.andExpect(status().isBadRequest())
 				.andDo(document("expenditure-post-amount-min-error",
@@ -169,6 +174,7 @@ public class ExpenditureDocsTest {
 			mockMvc.perform(post(BASE_URL)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(wrongResult))
+					.with(csrf())
 				)
 				.andExpect(status().isBadRequest())
 				.andDo(document("expenditure-post-amount-max-error",
@@ -191,6 +197,7 @@ public class ExpenditureDocsTest {
 			mockMvc.perform(post(BASE_URL)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(wrongResult))
+					.with(csrf())
 				)
 				.andExpect(status().isBadRequest())
 				.andDo(document("expenditure-post-content-max-error",
@@ -214,6 +221,7 @@ public class ExpenditureDocsTest {
 			mockMvc.perform(post(BASE_URL)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(wrongResult))
+					.with(csrf())
 				)
 				.andExpect(status().isBadRequest())
 				.andDo(document("expenditure-post-user-category-id-null",
@@ -232,6 +240,7 @@ public class ExpenditureDocsTest {
 			mockMvc.perform(post(BASE_URL)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request))
+					.with(csrf())
 				)
 				.andExpect(status().isForbidden())
 				.andDo(document("expenditure-create-forbidden",
@@ -250,6 +259,7 @@ public class ExpenditureDocsTest {
 			mockMvc.perform(post(BASE_URL)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request))
+				.with(csrf())
 			).andDo(document("expenditure-create",
 				requestFields(documentCreateExpenditureRequest()),
 				responseFields(documentCreateExpenditureResponse())
@@ -338,7 +348,5 @@ public class ExpenditureDocsTest {
 				fieldWithPath("categoryName").type(STRING).description("카테고리 이름")
 			);
 		}
-
 	}
-
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/IncomeDocsTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/IncomeDocsTest.java
@@ -1,4 +1,4 @@
-package com.prgrms.tenwonmoa.domain.accountbook.controller;
+package com.prgrms.tenwonmoa.domain.accountbook.controller.docs;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.prgrms.tenwonmoa.exception.message.Message.*;
@@ -28,6 +28,7 @@ import com.prgrms.tenwonmoa.common.documentdto.CreateIncomeRequestDoc;
 import com.prgrms.tenwonmoa.common.documentdto.ErrorResponseDoc;
 import com.prgrms.tenwonmoa.common.documentdto.FindIncomeResponseDoc;
 import com.prgrms.tenwonmoa.common.documentdto.UpdateIncomeRequestDoc;
+import com.prgrms.tenwonmoa.domain.accountbook.controller.IncomeController;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.CreateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.FindIncomeResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.UpdateIncomeRequest;
@@ -41,8 +42,8 @@ import com.prgrms.tenwonmoa.exception.UnauthorizedUserException;
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
 @MockBean(JpaMetamodelMappingContext.class)
-@DisplayName("수입 컨트롤러 테스트")
-class IncomeControllerTest {
+@DisplayName("수입 DOCS 테스트")
+class IncomeDocsTest {
 	private static final String LOCATION_PREFIX = "/api/v1/incomes/";
 
 	private final CreateIncomeRequest createIncomeRequest = new CreateIncomeRequest(
@@ -103,9 +104,9 @@ class IncomeControllerTest {
 			.willReturn(createdId);
 
 		mockMvc.perform(post(LOCATION_PREFIX)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createIncomeRequest))
+			)
 			.andExpect(status().isCreated())
 			.andExpect(redirectedUrl(LOCATION_PREFIX + createdId))
 			.andDo(document("income-create",
@@ -125,9 +126,9 @@ class IncomeControllerTest {
 			.willThrow(new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
 
 		mockMvc.perform(post(LOCATION_PREFIX)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(createIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createIncomeRequest))
+			)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-create-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -165,9 +166,9 @@ class IncomeControllerTest {
 	void 수입_수정_성공() throws Exception {
 		Long incomeId = 1L;
 		mockMvc.perform(put(LOCATION_PREFIX + "/{incomeId}", incomeId)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(updateIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateIncomeRequest))
+			)
 			.andExpect(status().isNoContent())
 			.andDo(document("income-update", requestFields(
 				UpdateIncomeRequestDoc.fieldDescriptors()
@@ -183,9 +184,9 @@ class IncomeControllerTest {
 
 		Long incomeId = 1L;
 		mockMvc.perform(put(LOCATION_PREFIX + "/{incomeId}", incomeId)
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(updateIncomeRequest))
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateIncomeRequest))
+			)
 			.andExpect(status().isBadRequest())
 			.andDo(document("income-update-fail", responseFields(
 				ErrorResponseDoc.fieldDescriptors()
@@ -197,8 +198,8 @@ class IncomeControllerTest {
 	void 수입_삭제_성공() throws Exception {
 		Long incomeId = 1L;
 		mockMvc.perform(delete(LOCATION_PREFIX + "/{incomeId}", incomeId)
-			.contentType(MediaType.APPLICATION_JSON)
-		)
+				.contentType(MediaType.APPLICATION_JSON)
+			)
 			.andExpect(status().isNoContent())
 			.andDo(document("income-delete"));
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/SearchAccountBookDocsTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/SearchAccountBookDocsTest.java
@@ -1,4 +1,4 @@
-package com.prgrms.tenwonmoa.domain.accountbook.controller;
+package com.prgrms.tenwonmoa.domain.accountbook.controller.docs;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse.*;
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
 import com.prgrms.tenwonmoa.config.JwtConfigure;
 import com.prgrms.tenwonmoa.config.WebSecurityConfig;
+import com.prgrms.tenwonmoa.domain.accountbook.controller.SearchAccountBookController;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.service.SearchAccountBookCmd;
 import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookService;
@@ -44,10 +45,10 @@ import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFil
 	}
 )
 @MockBean(JpaMetamodelMappingContext.class)
-@DisplayName("가계부 검색 컨트롤러 테스트")
+@DisplayName("가계부 검색 DOCS 테스트")
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
-class SearchAccountBookControllerTest {
+class SearchAccountBookDocsTest {
 
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/StatisticsDocsTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/StatisticsDocsTest.java
@@ -1,4 +1,4 @@
-package com.prgrms.tenwonmoa.domain.accountbook.controller;
+package com.prgrms.tenwonmoa.domain.accountbook.controller.docs;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static org.mockito.BDDMockito.*;
@@ -26,6 +26,7 @@ import com.prgrms.tenwonmoa.common.documentdto.FindStatisticsDataDoc;
 import com.prgrms.tenwonmoa.common.documentdto.FindStatisticsResponseDoc;
 import com.prgrms.tenwonmoa.config.JwtConfigure;
 import com.prgrms.tenwonmoa.config.WebSecurityConfig;
+import com.prgrms.tenwonmoa.domain.accountbook.controller.StatisticsController;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsData;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.statistics.FindStatisticsResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.service.StatisticsService;
@@ -40,8 +41,8 @@ import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFil
 )
 @AutoConfigureRestDocs
 @MockBean(JpaMetamodelMappingContext.class)
-@DisplayName("통계 컨트롤러 테스트")
-class StatisticsControllerTest {
+@DisplayName("통계 DOCS 테스트")
+class StatisticsDocsTest {
 	private static final List<String> INCOME_DEFAULT = List.of("용돈", "상여", "금융소득");
 	private static final List<String> EXPENDITURE_DEFAULT = List.of("교통/차량", "문화생활", "마트/편의점");
 	@Autowired

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/IncomeIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/IncomeIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.prgrms.tenwonmoa.domain.accountbook.controller;
+package com.prgrms.tenwonmoa.domain.accountbook.controller.intergration;
 
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
 import static com.prgrms.tenwonmoa.domain.category.CategoryType.*;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/SearchAccountBookIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/SearchAccountBookIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.prgrms.tenwonmoa.domain.accountbook.controller;
+package com.prgrms.tenwonmoa.domain.accountbook.controller.intergration;
 
 import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/StatisticsIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/StatisticsIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.prgrms.tenwonmoa.domain.accountbook.controller;
+package com.prgrms.tenwonmoa.domain.accountbook.controller.intergration;
 
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
 import static java.time.LocalDateTime.*;


### PR DESCRIPTION
pr이  너무 커지는 것같아서 끊어서 보냅니다.

## 개요

- 지출 등록과 조회 docs 테스트 진행
- intergration과 docs로 패키지 나눔
- build.gradle에서 jacoco coverage 라인 커버리지 80으로 제한

## 이슈 및 공유하고싶은 것

GlobalExceptionHandler에서 DateTimeParseException 우선 넣었습니다.. 이부분 이슈 및 조언 부탁드릴게요!
프론트에서 날짜 잘못넣어주면 못잡는 거 잡으려고 넣었습니다

테스트커버리지 설정을 잊었습니다 80으로 설정해두었습니다.
큰 문제 없을겁니다. 지금 라인커버리지로 91입니다...

<img width="609" alt="Screen Shot 2022-08-09 at 4 38 20" src="https://user-images.githubusercontent.com/52152200/183500253-466a34fa-0473-4fd9-8752-9662f9728e63.png">

