### PR TITLE
[#162] 달력 API 작성

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prgrms.tenwonmoa.domain.accountbook.dto.CalendarCondition;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindCalendarResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
@@ -71,6 +73,20 @@ public class AccountBookQueryController {
 	) {
 		MonthCondition condition = new MonthCondition(LocalDateTime.now(), year);
 		FindMonthAccountResponse response = accountBookQueryService.findMonthAccount(userId, condition);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/calendar/{date}")
+	public ResponseEntity<FindCalendarResponse> findCalendarAccount(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable
+		@DateTimeFormat(pattern = "yyyy-MM-dd")
+			LocalDate date
+	) {
+		CalendarCondition condition = new CalendarCondition(date);
+
+		FindCalendarResponse response = accountBookQueryService.findCalendarAccount(userId, condition);
+
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CalendarCondition.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/CalendarCondition.java
@@ -1,0 +1,27 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import java.time.LocalDate;
+import java.util.Calendar;
+
+public class CalendarCondition {
+
+	private final LocalDate date;
+	private static final Calendar CALENDAR_INSTANCE = Calendar.getInstance();
+
+	public CalendarCondition(LocalDate date) {
+		this.date = date;
+		CALENDAR_INSTANCE.set(getYear(), getMonth() - 1, 1);
+	}
+
+	public int getYear() {
+		return this.date.getYear();
+	}
+
+	public int getMonth() {
+		return this.date.getMonthValue();
+	}
+
+	public int getLastDayOfMonth() {
+		return CALENDAR_INSTANCE.getActualMaximum(CALENDAR_INSTANCE.DATE);
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/DateDetail.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/DateDetail.java
@@ -1,0 +1,14 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DateDetail extends FindSumResponse {
+
+	private final int day;
+
+	public DateDetail(int day, Long incomeSum, Long expenditureSum) {
+		super(incomeSum, expenditureSum);
+		this.day = day;
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindCalendarResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindCalendarResponse.java
@@ -1,0 +1,18 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import java.util.List;
+
+import com.prgrms.tenwonmoa.domain.common.page.ChunksCustom;
+
+import lombok.Getter;
+
+@Getter
+public class FindCalendarResponse extends ChunksCustom<DateDetail> {
+
+	private final int month;
+
+	public FindCalendarResponse(int month, List<DateDetail> results) {
+		super(results);
+		this.month = month;
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookQueryService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookQueryService.java
@@ -5,6 +5,8 @@ import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prgrms.tenwonmoa.domain.accountbook.dto.CalendarCondition;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindCalendarResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
@@ -37,5 +39,9 @@ public class AccountBookQueryService {
 
 	public FindMonthAccountResponse findMonthAccount(Long userId, MonthCondition condition) {
 		return accountBookQueryRepository.findMonthAccount(userId, condition);
+	}
+
+	public FindCalendarResponse findCalendarAccount(Long userId, CalendarCondition condition) {
+		return accountBookQueryRepository.findCalendarAccount(userId, condition);
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
@@ -440,13 +440,13 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 				condition);
 
 			List<DateDetail> results = calendarAccount.getResults();
+			int lastDay = results.size();
 
 			// 2020년 2월이 윤년인지
 			assertThat(calendarAccount.getMonth()).isEqualTo(2);
-			assertThat(results.size()).isEqualTo(29);
-			for (int i = 0; i < results.size(); i++) {
-				DateDetail dateDetail = results.get(i);
-				int day = i + 1;
+			assertThat(lastDay).isEqualTo(29);
+			for (int day = 1; day <= lastDay; day++) {
+				DateDetail dateDetail = results.get(day - 1);
 
 				if (day % 2 == 0) {
 					assertThat(dateDetail.getIncomeSum()).isEqualTo(0L);

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/AccountBookQueryRepositoryTest.java
@@ -444,9 +444,7 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 			// 2020년 2월이 윤년인지
 			assertThat(calendarAccount.getMonth()).isEqualTo(2);
 			assertThat(results.size()).isEqualTo(29);
-			
 			for (int i = 0; i < results.size(); i++) {
-
 				DateDetail dateDetail = results.get(i);
 				int day = i + 1;
 
@@ -459,6 +457,7 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 
 				if (day % 2 == 1) {
 
+					// 11일 이전에는 지출만 1000원
 					if (day < 11) {
 						assertThat(dateDetail.getIncomeSum()).isEqualTo(0L);
 						assertThat(dateDetail.getExpenditureSum()).isEqualTo(1000L);
@@ -466,6 +465,7 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 						continue;
 					}
 
+					// 19일 이후에는 수입만 1000원
 					if (day > 19) {
 						assertThat(dateDetail.getIncomeSum()).isEqualTo(1000L);
 						assertThat(dateDetail.getExpenditureSum()).isEqualTo(0L);
@@ -473,6 +473,7 @@ class AccountBookQueryRepositoryTest extends RepositoryTest {
 						continue;
 					}
 
+					// 11~19일에는 수입 지출 모두 1000원
 					if (day >= 11 && day <= 19) {
 						assertThat(dateDetail.getExpenditureSum()).isEqualTo(1000L);
 						assertThat(dateDetail.getIncomeSum()).isEqualTo(1000L);


### PR DESCRIPTION
## 개요

- 달력 API 구현

## 추가기능

달력의 데이터를 모두 보내주어야 하다보니 핵심은

- 월의 마지막 day를 알아야합니다.
- 이후 year와 month에 해당하는 day로 groupby 하였습니다.
- 이후 1 ~ lastDay까지 incomeSum과 expenditureSum 구하기, null이면 0원으로 바꿔서 데이터 보내주기

- 테스트는 윤년을 판단해서 제대로 보내주는지 확인하기 위해 2020년도 2월로 진행하였습니다!

## TODO

- 현재 비슷한 포맷에서 중복이 조금 보입니다.
- 이번 api 기능을 제닛한테 보내주고, 공통부분 관리와 테스트를 진행하겠습니다