### PR TITLE
[#171] 다른 유저의 카테고리 등록못하게 변경

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
@@ -36,6 +36,7 @@ public class IncomeTotalService {
 		Income income = incomeService.findById(incomeId);
 		income.validateOwner(authId);
 		UserCategory userCategory = userCategoryService.findById(updateIncomeRequest.getUserCategoryId());
+		userCategory.getUser().validateLoginUser(authId);
 		if (CategoryType.isExpenditure(userCategory.getCategory().getCategoryType())) {
 			incomeService.deleteById(incomeId);
 			expenditureRepository.save(

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalService.java
@@ -26,7 +26,7 @@ public class IncomeTotalService {
 
 	public Long createIncome(Long userId, CreateIncomeRequest createIncomeRequest) {
 		UserCategory userCategory = userCategoryService.findById(createIncomeRequest.getUserCategoryId());
-
+		userCategory.getUser().validateLoginUser(userId);
 		User authUser = userService.findById(userId);
 		Income income = createIncomeRequest.toEntity(authUser, userCategory, userCategory.getCategory().getName());
 		return incomeService.save(income);

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalService.java
@@ -22,6 +22,7 @@ public class BudgetTotalService {
 
 	public void createOrUpdateBudget(Long userId, CreateOrUpdateBudgetRequest createOrUpdateBudgetRequest) {
 		UserCategory userCategory = userCategoryService.findById(createOrUpdateBudgetRequest.getUserCategoryId());
+		userCategory.getUser().validateLoginUser(userId);
 		User authUser = userService.findById(userId);
 
 		budgetRepository.findByUserCategoryIdAndRegisterDate(createOrUpdateBudgetRequest.getUserCategoryId(),

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/IncomeIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/IncomeIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -123,9 +124,7 @@ class IncomeIntegrationTest extends BaseControllerIntegrationTest {
 
 	@Test
 	void 수입_등록_다른유저의_카테고리_등록시도_실패() throws Exception {
-		User otherUser = userRepository.saveAndFlush(new User("other@email.com", "other1234", "other"));
-		Category category = categoryRepository.save(new Category("other", INCOME));
-		UserCategory otherUserCategory = userCategoryRepository.save(new UserCategory(otherUser, category));
+		UserCategory otherUserCategory = getOtherUserCategory();
 
 		CreateIncomeRequest request = new CreateIncomeRequest(LocalDateTime.now(), 2000L, "content2",
 			otherUserCategory.getId());
@@ -171,6 +170,20 @@ class IncomeIntegrationTest extends BaseControllerIntegrationTest {
 	}
 
 	@Test
+	void 수입_수정_다른유저카테고리_실패() throws Exception {
+		UserCategory otherUserCategory = getOtherUserCategory();
+
+		UpdateIncomeRequest updateIncomeRequest = new UpdateIncomeRequest(LocalDateTime.now(), 2000L, "updateContent",
+			otherUserCategory.getId());
+
+		mvc.perform(put(LOCATION_PREFIX + "/{incomeId}", income.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateIncomeRequest))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
 	void 수입에서_지출로_변경() throws Exception {
 		Category otherCategory = categoryRepository.save(new Category("다른 카테고리", EXPENDITURE));
 		UserCategory otherUserCategory = userCategoryRepository.save(createUserCategory(loginUser, otherCategory));
@@ -184,6 +197,13 @@ class IncomeIntegrationTest extends BaseControllerIntegrationTest {
 
 		Optional<Income> findIncome = incomeRepository.findById(income.getId());
 		assertThat(findIncome).isEmpty();
+	}
+
+	private UserCategory getOtherUserCategory() {
+		User otherUser = userRepository.saveAndFlush(new User("other@email.com", "other1234", "other"));
+		Category category = categoryRepository.save(new Category("other", INCOME));
+		UserCategory otherUserCategory = userCategoryRepository.save(new UserCategory(otherUser, category));
+		return otherUserCategory;
 	}
 
 	private void validateCreateRequest(CreateIncomeRequest request, String expectMessage) throws Exception {

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/IncomeIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/IncomeIntegrationTest.java
@@ -122,6 +122,21 @@ class IncomeIntegrationTest extends BaseControllerIntegrationTest {
 	}
 
 	@Test
+	void 수입_등록_다른유저의_카테고리_등록시도_실패() throws Exception {
+		User otherUser = userRepository.saveAndFlush(new User("other@email.com", "other1234", "other"));
+		Category category = categoryRepository.save(new Category("other", INCOME));
+		UserCategory otherUserCategory = userCategoryRepository.save(new UserCategory(otherUser, category));
+
+		CreateIncomeRequest request = new CreateIncomeRequest(LocalDateTime.now(), 2000L, "content2",
+			otherUserCategory.getId());
+
+		mvc.perform(post(LOCATION_PREFIX).contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
 	void 수입_상세조회_성공() throws Exception {
 		mvc.perform(get(LOCATION_PREFIX + "/{incomeId}", income.getId()).header(HttpHeaders.AUTHORIZATION, accessToken))
 			.andExpect(status().isOk())

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeTotalServiceTest.java
@@ -21,6 +21,8 @@ import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.CreateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.income.UpdateIncomeRequest;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.CategoryType;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
 import com.prgrms.tenwonmoa.domain.user.User;
@@ -59,13 +61,18 @@ class IncomeTotalServiceTest {
 
 	@Test
 	void 수입_생성_성공() {
-		given(userCategoryService.findById(any())).willReturn(userCategory);
-		given(userService.findById(anyLong())).willReturn(user);
+		UserCategory mockUserCategory = mock(UserCategory.class);
+		given(userCategoryService.findById(any())).willReturn(mockUserCategory);
+		given(mockUserCategory.getUser()).willReturn(mockUser);
+		given(mockUserCategory.getCategory()).willReturn(new Category("income", CategoryType.INCOME));
+		doNothing().when(mockUser).validateLoginUser(any());
+		given(userService.findById(anyLong())).willReturn(mockUser);
 		given(incomeService.save(income)).willReturn(userId);
 
-		Long savedId = incomeTotalService.createIncome(userId, request);
+		incomeTotalService.createIncome(userId, request);
 		assertAll(
-			() -> assertThat(savedId).isEqualTo(userId),
+			() -> verify(userCategoryService).findById(any()),
+			() -> verify(userService).findById(any()),
 			() -> verify(incomeService).save(income)
 		);
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/budget/controller/intergration/BudgetIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/budget/controller/intergration/BudgetIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.tenwonmoa.domain.budget.controller.intergration;
 
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static com.prgrms.tenwonmoa.domain.category.CategoryType.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -75,6 +76,23 @@ public class BudgetIntegrationTest extends BaseControllerIntegrationTest {
 
 		Optional<Budget> findBudget = budgetRepository.findByUserCategoryIdAndRegisterDate(userCategory.getId(), now);
 		assertThat(findBudget).isPresent();
+	}
+
+	@Test
+	void 예산_등록_다른유저의_카테고리_등록시도_실패() throws Exception {
+		User otherUser = userRepository.saveAndFlush(new User("other@email.com", "other1234", "other"));
+		Category category = categoryRepository.save(new Category("other", INCOME));
+		UserCategory otherUserCategory = userCategoryRepository.save(new UserCategory(otherUser, category));
+
+		CreateOrUpdateBudgetRequest createOrUpdateBudgetRequest = new CreateOrUpdateBudgetRequest(
+			1000L, now, otherUserCategory.getId());
+
+		mvc.perform(put(LOCATION_PREFIX)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(createOrUpdateBudgetRequest))
+				.header(HttpHeaders.AUTHORIZATION, accessToken)
+			)
+			.andExpect(status().isForbidden());
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalServiceTest.java
@@ -43,14 +43,17 @@ class BudgetTotalServiceTest {
 	private User user = createUser();
 	private Category category = createExpenditureCategory();
 	private UserCategory userCategory = createUserCategory(user, category);
-	private Budget budget = new Budget(1000L, YearMonth.now(), user, userCategory);
 
 	private CreateOrUpdateBudgetRequest createOrUpdateBudgetRequest = new CreateOrUpdateBudgetRequest(
 		1000L, YearMonth.now(), userCategory.getId());
 
 	@Test
 	void 예산_생성_성공() {
-		given(userCategoryService.findById(any())).willReturn(userCategory);
+		UserCategory mockUserCategory = mock(UserCategory.class);
+		User mockUser = mock(User.class);
+		given(userCategoryService.findById(any())).willReturn(mockUserCategory);
+		given(mockUserCategory.getUser()).willReturn(mockUser);
+		doNothing().when(mockUser).validateLoginUser(any());
 		given(userService.findById(any())).willReturn(user);
 		given(budgetRepository.findByUserCategoryIdAndRegisterDate(
 			any(), any())).willReturn(Optional.empty());
@@ -67,8 +70,12 @@ class BudgetTotalServiceTest {
 	@Test
 	void 예산_생성_업데이트처리되는경우() {
 		Budget mockBudget = mock(Budget.class);
-		given(userCategoryService.findById(any())).willReturn(userCategory);
-		given(userService.findById(any())).willReturn(user);
+		UserCategory mockUserCategory = mock(UserCategory.class);
+		User mockUser = mock(User.class);
+		given(userCategoryService.findById(any())).willReturn(mockUserCategory);
+		given(mockUserCategory.getUser()).willReturn(mockUser);
+		doNothing().when(mockUser).validateLoginUser(any());
+		given(userService.findById(any())).willReturn(mockUser);
 		given(budgetRepository.findByUserCategoryIdAndRegisterDate(
 			any(), any())).willReturn(Optional.of(mockBudget));
 


### PR DESCRIPTION
## 문제
- 수입, 예산 등록시 다른 유저의 카테고리를 등록할 수 있다.

## 변경 전
- 요청한 유저카테고리가 해당 유저의 카테고리가 맞는지 확인하지 않는다.

## 변경 후
- 요청한 유저카테고리가 해당 유저의 카테고리가 맞는지 확인한다.
