### PR TITLE
[#175] 월 별 예산내역 조회 구현

### DIFF
--- a/docs/budget.adoc
+++ b/docs/budget.adoc
@@ -11,8 +11,16 @@ endif::[]
 include::{snippets}/budget-create/http-request.adoc[]
 
 Request Fields
-
 include::{snippets}/budget-create/request-fields.adoc[]
 
 .Response
 include::{snippets}/budget-create/http-response.adoc[]
+
+=== 월별 예산 조회
+
+.Request
+include::{snippets}/budget-findBy-registerDate/http-request.adoc[]
+.Response
+include::{snippets}/budget-findBy-registerDate/http-response.adoc[]
+Response Fields
+include::{snippets}/budget-findBy-registerDate/response-fields.adoc[]

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/Budget.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/Budget.java
@@ -54,6 +54,10 @@ public class Budget extends BaseEntity {
 		this.userCategory = userCategory;
 	}
 
+	public String getCategoryName() {
+		return this.userCategory.getCategoryName();
+	}
+
 	public void changeAmount(Long amount) {
 		validateAmount(amount);
 		this.amount = amount;

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/controller/BudgetController.java
@@ -1,15 +1,21 @@
 package com.prgrms.tenwonmoa.domain.budget.controller;
 
+import java.time.YearMonth;
+
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.tenwonmoa.domain.budget.dto.CreateOrUpdateBudgetRequest;
+import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetResponse;
+import com.prgrms.tenwonmoa.domain.budget.service.BudgetService;
 import com.prgrms.tenwonmoa.domain.budget.service.BudgetTotalService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,8 +25,8 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/budgets")
 public class BudgetController {
 	private static final String LOCATION_PREFIX = "/api/v1/budgets";
-
 	private final BudgetTotalService budgetTotalService;
+	private final BudgetService budgetService;
 
 	@PutMapping
 	public ResponseEntity<Void> createOrUpdate(@RequestBody @Valid CreateOrUpdateBudgetRequest request,
@@ -28,5 +34,14 @@ public class BudgetController {
 		budgetTotalService.createOrUpdateBudget(userId, request);
 
 		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping
+	public ResponseEntity<FindBudgetResponse> findBudgets(@AuthenticationPrincipal Long userId,
+		@RequestParam YearMonth registerDate) {
+		FindBudgetResponse findBudgetResponse = new FindBudgetResponse(
+			budgetService.findByUserIdAndRegisterDate(userId, registerDate)
+		);
+		return ResponseEntity.ok(findBudgetResponse);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/dto/FindBudgetData.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/dto/FindBudgetData.java
@@ -1,0 +1,26 @@
+package com.prgrms.tenwonmoa.domain.budget.dto;
+
+import com.prgrms.tenwonmoa.domain.budget.Budget;
+
+import lombok.Getter;
+
+@Getter
+public class FindBudgetData {
+	private Long id;
+	private String categoryName;
+	private Long amount;
+
+	public FindBudgetData(Long id, String categoryName, Long amount) {
+		this.id = id;
+		this.categoryName = categoryName;
+		this.amount = amount;
+	}
+
+	public static FindBudgetData of(Budget budget) {
+		return new FindBudgetData(
+			budget.getId(),
+			budget.getCategoryName(),
+			budget.getAmount()
+		);
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/dto/FindBudgetResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/dto/FindBudgetResponse.java
@@ -1,0 +1,14 @@
+package com.prgrms.tenwonmoa.domain.budget.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class FindBudgetResponse {
+	private List<FindBudgetData> budgets;
+
+	public FindBudgetResponse(List<FindBudgetData> budgets) {
+		this.budgets = budgets;
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetRepository.java
@@ -1,12 +1,17 @@
 package com.prgrms.tenwonmoa.domain.budget.repository;
 
 import java.time.YearMonth;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.prgrms.tenwonmoa.domain.budget.Budget;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
 	Optional<Budget> findByUserCategoryIdAndRegisterDate(Long userCategoryId, YearMonth registerDate);
+
+	@Query("select b from Budget b join fetch b.userCategory where b.registerDate=:registerDate and b.user.id=:userId")
+	List<Budget> findByUserIdAndRegisterDate(Long userId, YearMonth registerDate);
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetService.java
@@ -1,15 +1,27 @@
 package com.prgrms.tenwonmoa.domain.budget.service;
 
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetData;
 import com.prgrms.tenwonmoa.domain.budget.repository.BudgetRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class BudgetService {
 	private final BudgetRepository budgetRepository;
+
+	public List<FindBudgetData> findByUserIdAndRegisterDate(Long userId, YearMonth registerDate) {
+		return budgetRepository.findByUserIdAndRegisterDate(userId, registerDate)
+			.stream()
+			.map(FindBudgetData::of)
+			.collect(Collectors.toList());
+	}
 }

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -8,9 +8,25 @@ servers:
 tags: []
 paths:
   /api/v1/budgets:
+    get:
+      tags:
+      - api
+      operationId: budget-findBy-registerDate
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-budgets-1714066444'
+              examples:
+                budget-findBy-registerDate:
+                  value: "{\"budgets\":[{\"id\":1,\"categoryName\":\"교통/차량\",\"amount\"\
+                    :1000},{\"id\":2,\"categoryName\":\"문화생활\",\"amount\":2000},{\"\
+                    id\":3,\"categoryName\":\"마트/편의점\",\"amount\":3000}]}"
     put:
       tags:
-        - api
+      - api
       operationId: budget-create
       requestBody:
         content:
@@ -27,7 +43,7 @@ paths:
   /api/v1/expenditures:
     post:
       tags:
-        - api
+      - api
       operationId: expenditure-
       requestBody:
         content:
@@ -66,7 +82,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-expenditures-940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 expenditure-create-forbidden:
                   value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
@@ -75,7 +91,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-expenditures-940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 expenditure-post-amount-max-error:
                   value: "{\"messages\":[\"최대값은 1조입니다\"],\"status\":400}"
@@ -84,7 +100,7 @@ paths:
                 expenditure-post-amount-null:
                   value: "{\"messages\":[\"must not be null\"],\"status\":400}"
                 expenditure-post-user-category-id-null:
-                  value: "{\"messages\":[\"최대값은 1조입니다\",\"유저 카테고리 아이디를 채워주세요\"],\"\
+                  value: "{\"messages\":[\"유저 카테고리 아이디를 채워주세요\",\"최대값은 1조입니다\"],\"\
                     status\":400}"
                 expenditure-post-content-max-error:
                   value: "{\"messages\":[\"내용의 최대 길이는 50입니다\"],\"status\":400}"
@@ -102,7 +118,7 @@ paths:
   /api/v1/statistics:
     get:
       tags:
-        - api
+      - api
       operationId: statistics-find-
       responses:
         "200":
@@ -131,57 +147,57 @@ paths:
   /api/v1/account-book/search:
     get:
       tags:
-        - api
+      - api
       operationId: search-account-book
       parameters:
-        - name: categories
-          in: query
-          description: 유저카테고리 아이디
-          required: true
-          schema:
-            type: string
-        - name: minprice
-          in: query
-          description: 최소 가격
-          required: true
-          schema:
-            type: string
-        - name: maxprice
-          in: query
-          description: 최대 가격
-          required: true
-          schema:
-            type: string
-        - name: start
-          in: query
-          description: 시작 등록일
-          required: true
-          schema:
-            type: string
-        - name: end
-          in: query
-          description: 종료 등록일
-          required: true
-          schema:
-            type: string
-        - name: content
-          in: query
-          description: "지출, 수입의 내용"
-          required: true
-          schema:
-            type: string
-        - name: size
-          in: query
-          description: 페이지의 사이즈
-          required: true
-          schema:
-            type: string
-        - name: page
-          in: query
-          description: 페이지 번호
-          required: true
-          schema:
-            type: string
+      - name: categories
+        in: query
+        description: 유저카테고리 아이디
+        required: false
+        schema:
+          type: string
+      - name: minprice
+        in: query
+        description: 최소 가격
+        required: false
+        schema:
+          type: string
+      - name: maxprice
+        in: query
+        description: 최대 가격
+        required: false
+        schema:
+          type: string
+      - name: start
+        in: query
+        description: 시작 등록일
+        required: false
+        schema:
+          type: string
+      - name: end
+        in: query
+        description: 종료 등록일
+        required: false
+        schema:
+          type: string
+      - name: content
+        in: query
+        description: "지출, 수입의 내용"
+        required: false
+        schema:
+          type: string
+      - name: size
+        in: query
+        description: 페이지의 사이즈
+        required: false
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: 페이지 번호
+        required: false
+        schema:
+          type: string
       responses:
         "200":
           description: "200"
@@ -199,14 +215,14 @@ paths:
                         "amount" : 10000,
                         "content" : "점심",
                         "categoryName" : "식비",
-                        "registerTime" : "2022-08-09T19:29:30.331325"
+                        "registerTime" : "2022-08-10T03:15:25.062652"
                       }, {
                         "id" : 1,
                         "type" : "INCOME",
                         "amount" : 50000,
                         "content" : "용돈",
                         "categoryName" : "용돈",
-                        "registerTime" : "2022-08-09T19:29:30.331359"
+                        "registerTime" : "2022-08-10T03:15:25.062685"
                       } ],
                       "currentPage" : 1,
                       "nextPage" : 2,
@@ -217,22 +233,22 @@ paths:
   /api/v1/expenditures/{expenditureId}:
     get:
       tags:
-        - api
+      - api
       operationId: expenditure-get
       parameters:
-        - name: expenditureId
-          in: path
-          description: ""
-          required: true
-          schema:
-            type: string
+      - name: expenditureId
+        in: path
+        description: ""
+        required: true
+        schema:
+          type: string
       responses:
         "400":
           description: "400"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-expenditures-940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 expenditure-get-forbidden:
                   value: "{\"messages\":[\"해당 지출이 존재 하지 않습니다.\"],\"status\":400}"
@@ -244,25 +260,25 @@ paths:
                 $ref: '#/components/schemas/api-v1-expenditures-expenditureId2033270015'
               examples:
                 expenditure-get:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-09T19:29:28.025389\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-10T03:15:23.742267\"\
                     ,\"amount\":20000,\"content\":\"돈까스마시써\",\"userCategoryId\":3,\"\
                     categoryName\":\"식비\"}"
   /api/v1/incomes/:
     post:
       tags:
-        - api
+      - api
       operationId: income-create
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
             examples:
               income-create:
-                value: "{\"registerDate\":\"2022-08-09T19:29:29.932195\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-10T03:15:24.756833\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-create-fail:
-                value: "{\"registerDate\":\"2022-08-09T19:29:29.954818\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-10T03:15:24.779977\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "201":
@@ -279,7 +295,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-expenditures-940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-create-fail:
                   value: "{\"messages\":[\"해당 사용자 카테고리는 존재하지 않습니다.\"],\"status\":400}"
@@ -301,7 +317,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-expenditures-940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-find-by-id-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -313,7 +329,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-incomes-incomeId-1674408626'
               examples:
                 income-find-by-id:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-09T19:29:29.97026\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-10T03:15:24.793286\"\
                     ,\"amount\":1000,\"content\":\"content\",\"userCategoryId\":1,\"\
                     categoryName\":\"용돈\"}"
         "403":
@@ -321,7 +337,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-expenditures-940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-forbidden:
                   value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
@@ -340,13 +356,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/api-v1-incomes-1988379506'
+              $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
             examples:
               income-update:
-                value: "{\"registerDate\":\"2022-08-09T19:29:29.452099\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-10T03:15:24.43504\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
               income-update-fail:
-                value: "{\"registerDate\":\"2022-08-09T19:29:29.913171\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-10T03:15:24.738051\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
       responses:
         "204":
@@ -356,7 +372,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-expenditures-940438351'
+                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
               examples:
                 income-update-fail:
                   value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
@@ -376,7 +392,24 @@ paths:
           description: "204"
 components:
   schemas:
-    api-v1-expenditures-940438351:
+    api-v1-budgets-1714066444:
+      type: object
+      properties:
+        budgets:
+          type: array
+          items:
+            type: object
+            properties:
+              amount:
+                type: number
+                description: 예산 금액
+              id:
+                type: number
+                description: 예산 ID
+              categoryName:
+                type: string
+                description: 카테고리 이름
+    api-v1-incomes-incomeId-940438351:
       type: object
       properties:
         messages:
@@ -384,10 +417,10 @@ components:
           description: 예외 메시지
           items:
             oneOf:
-              - type: object
-              - type: boolean
-              - type: string
-              - type: number
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
         status:
           type: number
           description: 에러 코드
@@ -478,7 +511,7 @@ components:
         expenditureTotalSum:
           type: number
           description: 지출 총 합계
-    api-v1-incomes-1988379506:
+    api-v1-incomes-incomeId1988379506:
       type: object
       properties:
         amount:

--- a/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindBudgetDataDoc.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindBudgetDataDoc.java
@@ -1,0 +1,38 @@
+package com.prgrms.tenwonmoa.common.documentdto;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FindBudgetDataDoc {
+	ID(NUMBER, "id", "예산 ID"),
+	CATEGORY_NAME(STRING, "categoryName", "카테고리 이름"),
+	AMOUNT(NUMBER, "amount", "예산 금액");
+
+	private final JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField())
+			.type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> fieldDescriptors() {
+		return List.of(
+			ID.getFieldDescriptor(),
+			CATEGORY_NAME.getFieldDescriptor(),
+			AMOUNT.getFieldDescriptor()
+		);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
@@ -3,12 +3,14 @@ package com.prgrms.tenwonmoa.common.fixture;
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
 import com.prgrms.tenwonmoa.common.RepositoryTest;
 import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.budget.Budget;
 import com.prgrms.tenwonmoa.domain.category.Category;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
@@ -46,6 +48,10 @@ public class RepositoryFixture extends RepositoryTest {
 		return save(
 			new Expenditure(registerDate, amount, "content", userCategory.getCategoryName(), userCategory.getUser(),
 				userCategory));
+	}
+
+	public Budget saveBudget(Long amount, YearMonth registerDate, User user, UserCategory userCategory) {
+		return save(new Budget(100L, registerDate, user, userCategory));
 	}
 
 	public void iterateFixture(int count, IntConsumer function) {

--- a/src/test/java/com/prgrms/tenwonmoa/domain/budget/controller/intergration/BudgetIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/budget/controller/intergration/BudgetIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.tenwonmoa.domain.budget.controller.intergration;
 
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static com.prgrms.tenwonmoa.domain.category.CategoryType.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -10,8 +11,11 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -28,7 +32,7 @@ import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
 import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
 
-@DisplayName("수입 컨트롤러 통합 테스트")
+@DisplayName("예산 컨트롤러 통합 테스트")
 public class BudgetIntegrationTest extends BaseControllerIntegrationTest {
 	private static final String LOCATION_PREFIX = "/api/v1/budgets";
 	@Autowired
@@ -110,6 +114,37 @@ public class BudgetIntegrationTest extends BaseControllerIntegrationTest {
 		validateCreateRequest(createBudgetRequest, "2022-07-01");
 	}
 
+	@Test
+	void 예산_월별_조회_성공() throws Exception {
+		budgetRepository.save(new Budget(1000L, now, loginUser, userCategory));
+
+		mvc.perform(get(LOCATION_PREFIX)
+				.param("registerDate", now.toString())
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("budgets").exists())
+			.andExpect(jsonPath("budgets[0].id").exists())
+			.andExpect(jsonPath("budgets[0].categoryName").exists())
+			.andExpect(jsonPath("budgets[0].amount").exists());
+	}
+
+	@Test
+	void 예산_월별_조회_잘못된_등록일포맷요청() throws Exception {
+		validateFindRequest("2022-13");
+		validateFindRequest("2022-00");
+		validateFindRequest("202211");
+		validateFindRequest("20220701");
+		validateFindRequest("2022-07-01");
+		validateFindRequest("2022-7");
+	}
+
+	private void validateFindRequest(String registerDate) throws Exception {
+		mvc.perform(put(LOCATION_PREFIX)
+				.param("registerDate", now.toString())
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(status().isBadRequest());
+	}
+
 	private void validateCreateRequest(ObjectNode createBudgetRequest, String registerDate) throws Exception {
 		createBudgetRequest.put("registerDate", registerDate);
 
@@ -121,4 +156,12 @@ public class BudgetIntegrationTest extends BaseControllerIntegrationTest {
 			.andExpect(status().isBadRequest());
 	}
 
+	@Disabled
+	@CsvSource({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"})
+	@ParameterizedTest(name = "{0}월 테스트")
+	void 예산_월별_조회_성공_모든월_돌려보기(int month) throws Exception {
+		mvc.perform(get(LOCATION_PREFIX)
+			.param("registerDate", YearMonth.of(2022, month).toString())
+			.header(HttpHeaders.AUTHORIZATION, accessToken)).andExpect(status().isOk());
+	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetRepositoryTest.java
@@ -5,52 +5,60 @@ import static com.prgrms.tenwonmoa.domain.category.CategoryType.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.YearMonth;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.prgrms.tenwonmoa.common.fixture.RepositoryFixture;
 import com.prgrms.tenwonmoa.domain.budget.Budget;
+import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetData;
 import com.prgrms.tenwonmoa.domain.category.Category;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
 
+import lombok.extern.slf4j.Slf4j;
+
 @DisplayName("예산 Repository 테스트")
+@Slf4j
 class BudgetRepositoryTest extends RepositoryFixture {
 	@Autowired
 	private BudgetRepository budgetRepository;
 
-	private UserCategory userCategory;
-	private UserCategory otherUserCategory;
+	private UserCategory userCategory1;
+	private UserCategory userCategory2;
+	private User user;
 	private YearMonth now = YearMonth.now();
 
 	@BeforeEach
 	void init() {
-		User user = save(createUser());
+		user = save(createUser());
 		Category category = save(createExpenditureCategory());
 		Category otherCategory = save(new Category("other", EXPENDITURE));
-		userCategory = save(createUserCategory(user, category));
-		otherUserCategory = save(createUserCategory(user, otherCategory));
-		budgetRepository.save(new Budget(100L, now, user, userCategory));
+		userCategory1 = save(createUserCategory(user, category));
+		userCategory2 = save(createUserCategory(user, otherCategory));
+
+		saveBudget(100L, now, user, userCategory1);
 	}
 
 	@Test
 	void 유저카테고리이름_등록날짜로_조회성공() {
-		Optional<Budget> findBudget = budgetRepository.findByUserCategoryIdAndRegisterDate(userCategory.getId(), now);
+		Optional<Budget> findBudget = budgetRepository.findByUserCategoryIdAndRegisterDate(userCategory1.getId(), now);
 
 		assertThat(findBudget).isPresent();
 		Budget budget = findBudget.get();
 		assertThat(budget.getAmount()).isEqualTo(100L);
-		assertThat(budget.getUserCategory()).isEqualTo(userCategory);
+		assertThat(budget.getUserCategory()).isEqualTo(userCategory1);
 		assertThat(budget.getRegisterDate()).isEqualTo(now);
 	}
 
 	@Test
 	void 유저카테고리이름_등록안된날짜로_조회() {
-		Optional<Budget> findBudget = budgetRepository.findByUserCategoryIdAndRegisterDate(userCategory.getId(),
+		Optional<Budget> findBudget = budgetRepository.findByUserCategoryIdAndRegisterDate(userCategory1.getId(),
 			now.plusMonths(1));
 
 		assertThat(findBudget).isEmpty();
@@ -58,9 +66,44 @@ class BudgetRepositoryTest extends RepositoryFixture {
 
 	@Test
 	void 유저카테고리이름_등록안된_카테고리로_조회() {
-		Optional<Budget> findBudget = budgetRepository.findByUserCategoryIdAndRegisterDate(otherUserCategory.getId(),
+		Optional<Budget> findBudget = budgetRepository.findByUserCategoryIdAndRegisterDate(userCategory2.getId(),
 			now);
 
 		assertThat(findBudget).isEmpty();
+	}
+
+	@Test
+	void 등록일로_조회_성공() {
+		Category category3 = save(new Category("other3", EXPENDITURE));
+		Category category4 = save(new Category("other4", EXPENDITURE));
+		UserCategory userCategory3 = save(createUserCategory(user, category3));
+		UserCategory userCategory4 = save(createUserCategory(user, category4));
+		saveBudget(200L, now, user, userCategory2);
+		saveBudget(300L, now, user, userCategory3);
+		saveBudget(400L, now.plusMonths(1), user, userCategory4);
+
+		List<Budget> findBudgets = budgetRepository.findByUserIdAndRegisterDate(user.getId(), now);
+		List<Budget> findBudgets2 = budgetRepository.findByUserIdAndRegisterDate(user.getId(), now.plusMonths(1));
+		List<Budget> findBudgets3 = budgetRepository.findByUserIdAndRegisterDate(user.getId(), now.plusMonths(2));
+
+		assertThat(findBudgets).hasSize(3);
+		assertThat(findBudgets2).hasSize(1);
+		assertThat(findBudgets3).isEmpty();
+	}
+
+	@Test
+	@Disabled
+	void 엔플러스일_확인() {
+		saveBudget(200L, now, user, userCategory2);
+
+		List<Budget> findBudgets = budgetRepository.findByUserIdAndRegisterDate(user.getId(), now);
+		log.info("=== findByRegisterDate의 Query를 지우면 of를 돌면서 쿼리가나간다. === ");
+		findBudgets.forEach(
+			(budget) -> {
+				log.info("=== start === ");
+				FindBudgetData.of(budget);
+				log.info("=== end === ");
+			}
+		);
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetServiceTest.java
@@ -1,0 +1,52 @@
+package com.prgrms.tenwonmoa.domain.budget.service;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.YearMonth;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.tenwonmoa.domain.budget.Budget;
+import com.prgrms.tenwonmoa.domain.budget.repository.BudgetRepository;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.service.UserService;
+
+@DisplayName("예산 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class BudgetServiceTest {
+	@Mock
+	private BudgetRepository budgetRepository;
+	@Mock
+	private UserService userService;
+	@Mock
+	private UserCategoryService userCategoryService;
+	@InjectMocks
+	private BudgetService budgetService;
+
+	private User user = createUser();
+	private Category category = createExpenditureCategory();
+	private UserCategory userCategory = createUserCategory(user, category);
+
+	private YearMonth now = YearMonth.now();
+	private Long userId = 1L;
+
+	List<Budget> budgets = List.of(new Budget(100L, now, user, userCategory));
+
+	@Test
+	void 월별_예산조회_성공() {
+		given(budgetRepository.findByUserIdAndRegisterDate(userId, now)).willReturn(budgets);
+		// when
+		budgetService.findByUserIdAndRegisterDate(userId, now);
+		verify(budgetRepository).findByUserIdAndRegisterDate(userId, now);
+	}
+}


### PR DESCRIPTION
## 개요

- 월 별 예산내역 조회 구현

## 추가기능

- `/budgets?registerDate={yyyy-mm}` 요청으로 월 별 예산내역을 조회할 수 있다.

## 사용방법(Optional)

- 로그인 사용자는 예산등록날짜(yyyy-mm)을 기준으로 예산정보를 조회할 수 있다.

## 기타

![https://user-images.githubusercontent.com/26343023/183725613-72a884cd-2dc6-40d3-88e1-0541638d650e.png](https://user-images.githubusercontent.com/26343023/183725613-72a884cd-2dc6-40d3-88e1-0541638d650e.png)

## 기타2
- [해당 pr](https://github.com/prgrms-web-devcourse/Team-10jo-10wonmoa-BE/pull/174) merge 후 반영할 예정입니다 !