### PR TITLE
[#179] 마이페이지 유저 정보 조회 API

### DIFF
--- a/docs/user.adoc
+++ b/docs/user.adoc
@@ -15,4 +15,13 @@ include::{snippets}/user-create/request-fields.adoc[]
 include::{snippets}/user-create/http-response.adoc[]
 
 
+=== 유저 정보 조회
+
+.Request
+include::{snippets}/user-info/http-request.adoc[]
+
+.Response
+include::{snippets}/user-info/http-response.adoc[]
+
+
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/controller/UserController.java
@@ -28,7 +28,7 @@ public class UserController {
 	private final UserService userService;
 
 	@GetMapping
-	public ResponseEntity<FindUserResponse> getUserInfo(@AuthenticationPrincipal Long userId){
+	public ResponseEntity<FindUserResponse> getUserInfo(@AuthenticationPrincipal Long userId) {
 		return ResponseEntity.ok(FindUserResponse.of(userService.findById(userId)));
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/controller/UserController.java
@@ -4,12 +4,15 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
+import com.prgrms.tenwonmoa.domain.user.dto.FindUserResponse;
 import com.prgrms.tenwonmoa.domain.user.dto.LoginUserRequest;
 import com.prgrms.tenwonmoa.domain.user.dto.RefreshTokenRequest;
 import com.prgrms.tenwonmoa.domain.user.dto.TokenResponse;
@@ -23,6 +26,11 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
 	private final UserService userService;
+
+	@GetMapping
+	public ResponseEntity<FindUserResponse> getUserInfo(@AuthenticationPrincipal Long userId){
+		return ResponseEntity.ok(FindUserResponse.of(userService.findById(userId)));
+	}
 
 	@PostMapping
 	public ResponseEntity<Void> signup(@Valid @RequestBody CreateUserRequest createUserRequest) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/dto/FindUserResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/dto/FindUserResponse.java
@@ -3,16 +3,16 @@ package com.prgrms.tenwonmoa.domain.user.dto;
 import com.prgrms.tenwonmoa.domain.user.User;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public final class FindUserResponse {
 
 	private final String email;
 
-	private final String username;
-
 	public static FindUserResponse of(User user) {
-		return new FindUserResponse(user.getEmail(), user.getUsername());
+		return new FindUserResponse(user.getEmail());
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/dto/FindUserResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/dto/FindUserResponse.java
@@ -1,0 +1,18 @@
+package com.prgrms.tenwonmoa.domain.user.dto;
+
+import com.prgrms.tenwonmoa.domain.user.User;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public final class FindUserResponse {
+
+	private final String email;
+
+	private final String username;
+
+	public static FindUserResponse of(User user) {
+		return new FindUserResponse(user.getEmail(), user.getUsername());
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/SearchAccountBookIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/SearchAccountBookIntegrationTest.java
@@ -135,6 +135,27 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 	}
 
 	@Test
+	void 내용이_공백인_지출_수입_검색_성공() throws Exception {
+		//given
+		Long incomeCategoryId = 카테고리_등록("INCOME", "월급");
+		Long expenditureCategoryId = 카테고리_등록("EXPENDITURE", "식비");
+		수입_등록(incomeCategoryId, 10000L, "", LocalDateTime.now());
+		지출_등록(expenditureCategoryId, 5000L, "", LocalDateTime.now());
+
+		//when
+		//then
+		mvc.perform(get("/api/v1/account-book/search")
+				.header(HttpHeaders.AUTHORIZATION, accessToken))
+			.andExpect(jsonPath("$.incomeSum").value(10000L))
+			.andExpect(jsonPath("$.expenditureSum").value(5000L))
+			.andExpect(jsonPath("$.totalSum").value(5000L))
+			.andExpect(jsonPath("$.currentPage").value(1))
+			.andExpect(jsonPath("$.nextPage").isEmpty())
+			.andExpect(jsonPath("$.results", hasSize(2)));
+
+	}
+
+	@Test
 	void 금액의_범위를_벗어나는_값_전송시_조회_실패() throws Exception {
 		validateRequest("minprice", "-1");
 		validateRequest("maxprice", "-1");

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/SearchAccountBookRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/SearchAccountBookRepositoryTest.java
@@ -269,4 +269,23 @@ class SearchAccountBookRepositoryTest extends RepositoryTest {
 				CategoryType.EXPENDITURE.name(), CategoryType.INCOME.name());
 
 	}
+
+	@Test
+	void 내용이_공백인_데이터_조회() {
+		//given
+		saveExpenditure(defaultTime, defaultAmount, "",
+			expenditureUserCategory.getCategoryName(), user, expenditureUserCategory);
+
+		saveIncome(defaultTime, defaultAmount, "",
+			incomeUserCategory.getCategoryName(), user, incomeUserCategory);
+
+		//when
+		List<AccountBookItem> items = repository.searchAccountBook(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE,
+			RIGHT_MOST_REGISTER_DATE, "", allUserCategoryIds, user.getId(),
+			new PageCustomRequest(1, 10));
+
+		//then
+		assertThat(items).hasSize(2);
+	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
@@ -14,6 +14,8 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -23,12 +25,20 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
+import com.prgrms.tenwonmoa.config.JwtConfigure;
+import com.prgrms.tenwonmoa.config.WebSecurityConfig;
 import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
 import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
-@WebMvcTest(UserController.class)
+@WebMvcTest(controllers = UserController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfig.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtConfigure.class),
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+	}
+)
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
 @MockBean(JpaMetamodelMappingContext.class)

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
@@ -76,7 +76,7 @@ class UserControllerTest {
 		given(userService.findById(1L)).willReturn(user);
 
 		mockMvc.perform(get("/api/v1/users")
-				.header(HttpHeaders.AUTHORIZATION, "mock-token"))
+				.header(HttpHeaders.AUTHORIZATION, "Bearer jwt.token.here"))
 			.andExpect(status().isOk())
 			.andDo(MockMvcRestDocumentationWrapper.document("user-info",
 				requestHeaders(

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
@@ -1,7 +1,6 @@
 package com.prgrms.tenwonmoa.domain.user.controller;
 
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -19,7 +18,10 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
+import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
 import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
 import com.prgrms.tenwonmoa.domain.user.service.UserService;
@@ -57,7 +59,7 @@ class UserControllerTest {
 				.content(objectMapper.writeValueAsString(createUserRequest)))
 			.andExpect(status().isCreated())
 			.andDo(print())
-			.andDo(document("user-create",
+			.andDo(MockMvcRestDocumentationWrapper.document("user-create",
 				requestFields(
 					fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
 					fieldWithPath("username").type(JsonFieldType.STRING).description("사용자이름"),
@@ -65,4 +67,21 @@ class UserControllerTest {
 			));
 	}
 
+	@Test
+	@WithMockCustomUser
+	void 회원_정보_조회_성공() throws Exception {
+		User user = new User("test@test.com", "lee", "12345678");
+		given(userService.findById(1L)).willReturn(user);
+
+		mockMvc.perform(get("/api/v1/users")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(print())
+			.andDo(MockMvcRestDocumentationWrapper.document("user-info",
+				responseFields(
+					fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+					fieldWithPath("username").type(JsonFieldType.STRING).description("사용자이름")
+				)));
+
+	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.tenwonmoa.domain.user.controller;
 
 import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -74,14 +76,15 @@ class UserControllerTest {
 		given(userService.findById(1L)).willReturn(user);
 
 		mockMvc.perform(get("/api/v1/users")
-				.accept(MediaType.APPLICATION_JSON))
+				.header(HttpHeaders.AUTHORIZATION, "mock-token"))
 			.andExpect(status().isOk())
-			.andDo(print())
 			.andDo(MockMvcRestDocumentationWrapper.document("user-info",
+				requestHeaders(
+					headerWithName(HttpHeaders.AUTHORIZATION).description("Jwt token")
+				),
 				responseFields(
-					fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-					fieldWithPath("username").type(JsonFieldType.STRING).description("사용자이름")
-				)));
-
+					fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
+				))
+			);
 	}
 }


### PR DESCRIPTION
## 개요

- 유저 정보 조회 구현

## 추가기능

- 유저 정보 조회 & 단위 테스트 & adoc
- 검색 API 테스트 2개 추가(죄송해요 여기에 섞여 버렸어요..  내용이 비어 있는 지출, 수입에 대해서도 검색 가능하다는 테스트에요! 짤막합니다)

## 사용방법(Optional)

- token 넣고 api 요청하면 이메일 반환합니다

<img width="485" alt="image" src="https://user-images.githubusercontent.com/78348340/183853254-50d419b4-fad0-4ad9-9fb6-d534adeb4ab0.png">
