### PR TITLE
[#170] 슬랙 로깅 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ out/
 
 ### Private ###
 /src/main/resources/application-dev.yml
-/src/main/resources/application-oauth.yml
+/src/main/resources/application-custom.yml

--- a/build.gradle
+++ b/build.gradle
@@ -82,9 +82,13 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'com.auth0:java-jwt:3.18.1'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    // REST-DOCS <-> swagger
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.0'
+
+    // Slack logging
+    implementation 'com.github.maricn:logback-slack-appender:1.4.0'
 }
 
 test {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    default: local, oauth
+    default: local, custom

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,37 @@
+<configuration>
+    <conversionRule
+            conversionWord="clr"
+            converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{HH:mm:ss.SSS}){cyan} [%thread] %clr(%-5level) %logger{36} - %msg%n"/>
+    <springProperty name="SLACK_WEBHOOK_URL" source="logging.slack.webhook-url"/>
+
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URL}</webhookUri>
+        <username>${HOSTNAME}</username>
+        <iconEmoji>:stuck_out_tongue_winking_eye:</iconEmoji>
+        <colorCoding>true</colorCoding>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %msg %n</pattern>
+        </layout>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="ASYNC_SLACK"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## 개요

- 에러 레벨에 대해서는 슬랙 채널로 로그 메시지 보내도록 설정하였음

## 추가기능

- 슬랙 채널로 에러 레벨 로깅 전송
- 채널 이름: #10조-슬랙-로깅

## 변경사항(Optional)

- application-oauth.yml -> application-custom.yml 로 변경함 (따로 관리하는 설정값들 로컬에서는 custom으로 관리하고
dev 서버에서는 submodule에서 가져오도록 하면 좋지 않을까요?)
- submodule에 application-dev.yml 파일 수정


## 사용방법(Optional)
- log.error로 사용되는 로그 메시지들은 슬랙으로도 날아갑니다

## 기타
슬랙 로깅 설정방법 노션에 미션 아래 정리해두었습니다