### PR TITLE
[#201] 구글 로그인 중 username 오류 해결

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/User.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/User.java
@@ -31,7 +31,21 @@ public class User extends BaseEntity {
 	@Column(name = "username", nullable = false)
 	private String username;
 
+	@Column(name = "from_social")
+	private boolean fromSocial;
+
 	public User(String email, String password, String username) {
+		this.fromSocial = false;
+		validateEmail(email);
+		validatePassword(password);
+		validateUsername(username);
+		this.email = email;
+		this.password = password;
+		this.username = username;
+	}
+
+	public User(String email, String password, String username, boolean fromSocial) {
+		this.fromSocial = fromSocial;
 		validateEmail(email);
 		validatePassword(password);
 		validateUsername(username);
@@ -48,9 +62,11 @@ public class User extends BaseEntity {
 
 	private void validateUsername(String username) {
 		checkNotNull(username, NOT_NULL_USERNAME.getMessage());
-		checkArgument(username.length() >= MIN_USERNAME_LENGTH && username.length() <= MAX_USERNAME_LENGTH,
-			INVALID_USERNAME_LENGTH.getMessage());
-		checkArgument(username.matches(USERNAME_REGEX), INVALID_USERNAME_PATTERN.getMessage());
+		if (!fromSocial) {
+			checkArgument(username.length() >= MIN_USERNAME_LENGTH && username.length() <= MAX_USERNAME_LENGTH,
+				INVALID_USERNAME_LENGTH.getMessage());
+			checkArgument(username.matches(USERNAME_REGEX), INVALID_USERNAME_PATTERN.getMessage());
+		}
 	}
 
 	private void validatePassword(String password) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/security/oauth2/service/OAuth2UserDetailsService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/security/oauth2/service/OAuth2UserDetailsService.java
@@ -9,11 +9,10 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prgrms.tenwonmoa.domain.category.service.CreateDefaultUserCategoryService;
 import com.prgrms.tenwonmoa.domain.user.User;
-import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
 import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
 import com.prgrms.tenwonmoa.domain.user.security.oauth2.OAuth2UserPrincipal;
-import com.prgrms.tenwonmoa.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,8 +21,8 @@ import lombok.RequiredArgsConstructor;
 public class OAuth2UserDetailsService extends DefaultOAuth2UserService {
 
 	private static final String DEFAULT_OAUTH_PASSWORD = "oauthuser";
-	private final UserService userService;
 	private final UserRepository userRepository;
+	private final CreateDefaultUserCategoryService createDefaultUserCategoryService;
 
 	@Transactional
 	@Override
@@ -49,9 +48,10 @@ public class OAuth2UserDetailsService extends DefaultOAuth2UserService {
 			return findUser.get().getId();
 		}
 
-		CreateUserRequest createUserRequest = new CreateUserRequest(email, name, DEFAULT_OAUTH_PASSWORD);
-		Long userId = userService.createUser(createUserRequest);
+		User socialUser = new User(email, DEFAULT_OAUTH_PASSWORD, name, true);
+		User savedSocialUser = userRepository.save(socialUser);
+		createDefaultUserCategoryService.createDefaultUserCategory(savedSocialUser);
 
-		return userId;
+		return savedSocialUser.getId();
 	}
 }

--- a/src/main/resources/db/migration/V1_0_4__user_from_social_add.sql
+++ b/src/main/resources/db/migration/V1_0_4__user_from_social_add.sql
@@ -1,0 +1,1 @@
+alter table user add from_social boolean;


### PR DESCRIPTION
## 개요

- 구글 로그인 중 구글 계정에서 name을 가져오는데, 구글 계정의 name이 공백을 포함하거나 특수문자를 포함할 경우 
서버 로직에서 회원가입 중 에러가 발생

## 변경 후
- 소셜 로그인은 validation 없이 username을 저장