### PR TITLE
[#199] flyway plugin 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'jacoco'
     id "org.asciidoctor.jvm.convert" version "3.3.2"
     id 'com.epages.restdocs-api-spec' version '0.16.0'
-    id "org.flywaydb.flyway" version "9.1.3"
+    id "org.flywaydb.flyway" version "8.2.0"
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,7 @@ openapi3 {
 }
 
 flyway {
-    url = "jdbc:mysql://localhost:3306/tenwonmoa?serverTimezone=UTC&characterEncoding=UTF-8"
+    url = "jdbc:mysql://localhost:3306/tenwonmoa-test?serverTimezone=UTC&characterEncoding=UTF-8"
     user = "root"
     password = "root1234"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'jacoco'
     id "org.asciidoctor.jvm.convert" version "3.3.2"
     id 'com.epages.restdocs-api-spec' version '0.16.0'
+    id "org.flywaydb.flyway" version "9.1.3"
 }
 
 ext {
@@ -208,6 +209,12 @@ openapi3 {
     description = 'Tenwonmoa API description'
     version = '1.0.0'
     format = 'yaml'
+}
+
+flyway {
+    url = "jdbc:mysql://localhost:3306/tenwonmoa?serverTimezone=UTC&characterEncoding=UTF-8"
+    user = "root"
+    password = "root1234"
 }
 
 task copyOpenApi(type: Copy) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,6 +31,8 @@ spring:
 logging:
   level:
     org.hibernate.type: trace
+  slack:
+    webhook-url: https://hooks.slack.com/services
 
 jwt:
   header: testToken


### PR DESCRIPTION
## 개요

- flyway plugin을 통해서 migrate, clean 클릭만으로 한번에 가능함

## 변경사항
 - test에 있는 application.yml 에 slack webhook url 을 추가했습니다. 테스트할때 에러 뜨는게 보기 싫어서 추가했고 별 의미는 없습니다.
 - test 할때 Spring ApplicationContext 생성 시에 logback 설정도 같이 진행해서 에러 뜨는 듯 합니다

## 추가기능

- flyway plugin 추가

## 사용방법(Optional)
![image](https://user-images.githubusercontent.com/78348340/184126317-d968941c-7367-4058-84f7-a2b924954282.png)
- flywayMigrate는 db.migration 에 있는 sql 기반으로 migration 한번에 해줌
- flywayClean 은 해당 스키마 다 날려줌
- 현재는 localhost:3306/tenwonmoa-test  에 대해서 설정되어 있습니다. 사실 이 plugin은 로컬이나 개발 환경에서 쓰기에 편한거라
실제 tenwonmoa 스키마에는 많이 적용할 일 없을것 같아 tenwonmoa-test로 설정했습니다.
만약 tenwonmoa 에 대해서 하시고 싶으면 build.gradle에 아래 부분을 변경하시면 됩니다
![image](https://user-images.githubusercontent.com/78348340/184126588-b3a2bf9f-3a0a-42fd-a67d-8ae013e79598.png)
