### PR TITLE
[#215] 검색 합계 API 구현 [리포지토리]

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.prgrms.tenwonmoa.domain.accountbook.dto.AccountBookItem;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.service.SearchAccountBookCmd;
 import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookService;
@@ -37,7 +36,7 @@ public class SearchAccountBookController {
 	private final FindUserCategoryService userCategoryService;
 
 	@GetMapping("/search")
-	public ResponseEntity<FindAccountBookResponse<AccountBookItem>> searchAccountBooks(
+	public ResponseEntity<FindAccountBookResponse> searchAccountBooks(
 		@AuthenticationPrincipal Long userId,
 		@RequestParam(defaultValue = "") String categories,
 		@RequestParam(defaultValue = "") String content,
@@ -53,7 +52,7 @@ public class SearchAccountBookController {
 
 		PageCustomRequest pageRequest = new PageCustomRequest(page, size);
 
-		FindAccountBookResponse<AccountBookItem> response = accountBookService.searchAccountBooks(userId,
+		FindAccountBookResponse response = accountBookService.searchAccountBooks(userId,
 			SearchAccountBookCmd.of(categories, minPrice, maxPrice, start, end, content), pageRequest);
 
 		return ResponseEntity.ok(response);

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindAccountBookResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindAccountBookResponse.java
@@ -8,24 +8,13 @@ import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
 import lombok.Getter;
 
 @Getter
-public final class FindAccountBookResponse<T> extends PageCustomImpl<T> {
-
-	private final Long incomeSum;
-
-	private final Long expenditureSum;
-
-	private final Long totalSum;
-
-	private FindAccountBookResponse(PageCustomRequest pageRequest, List<T> results,
-		Long incomeSum, Long expenditureSum) {
+public final class FindAccountBookResponse extends PageCustomImpl<AccountBookItem> {
+	private FindAccountBookResponse(PageCustomRequest pageRequest, List<AccountBookItem> results) {
 		super(pageRequest, results);
-		this.expenditureSum = expenditureSum;
-		this.incomeSum = incomeSum;
-		this.totalSum = incomeSum - expenditureSum;
 	}
 
-	public static <T> FindAccountBookResponse<T> of(PageCustomRequest pageRequest,
-		List<T> results, Long incomeSum, Long expenditureSum) {
-		return new FindAccountBookResponse<>(pageRequest, results, incomeSum, expenditureSum);
+	public static FindAccountBookResponse of(PageCustomRequest pageRequest,
+		List<AccountBookItem> results) {
+		return new FindAccountBookResponse(pageRequest, results);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/service/SearchAccountBookCmd.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/service/SearchAccountBookCmd.java
@@ -1,6 +1,10 @@
 package com.prgrms.tenwonmoa.domain.accountbook.dto.service;
 
+import static com.google.common.base.Preconditions.*;
+
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,14 +24,15 @@ public final class SearchAccountBookCmd {
 
 	private Long maxPrice;
 
-	private LocalDate start;
+	private LocalDateTime start;
 
-	private LocalDate end;
+	private LocalDateTime end;
 
 	private String content;
 
 	public static SearchAccountBookCmd of(String categoryString, Long minPrice, Long maxPrice, LocalDate start,
 		LocalDate end, String content) {
+
 		String[] categoryIds = categoryString.split(",");
 		List<Long> categories = Arrays.stream(categoryIds).map(Long::valueOf).collect(Collectors.toList());
 
@@ -36,7 +41,11 @@ public final class SearchAccountBookCmd {
 		start = start == null ? AccountBookConst.LEFT_MOST_REGISTER_DATE : start;
 		end = end == null ? AccountBookConst.RIGHT_MOST_REGISTER_DATE : end;
 
-		return new SearchAccountBookCmd(categories, minPrice, maxPrice, start, end, content);
+		checkArgument(minPrice <= maxPrice, "최소값은 최대값 보다 작아야 합니다");
+		checkArgument(start.compareTo(end) <= 0, "시작일은 종료일 전이여야 합니다");
+
+		return new SearchAccountBookCmd(categories, minPrice, maxPrice, start.atTime(LocalTime.MIN),
+			end.atTime(LocalTime.MAX), content);
 	}
 
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/service/SearchAccountBookCmd.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/service/SearchAccountBookCmd.java
@@ -1,6 +1,7 @@
 package com.prgrms.tenwonmoa.domain.accountbook.dto.service;
 
 import static com.google.common.base.Preconditions.*;
+import static com.prgrms.tenwonmoa.exception.message.Message.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -41,8 +42,8 @@ public final class SearchAccountBookCmd {
 		start = start == null ? AccountBookConst.LEFT_MOST_REGISTER_DATE : start;
 		end = end == null ? AccountBookConst.RIGHT_MOST_REGISTER_DATE : end;
 
-		checkArgument(minPrice <= maxPrice, "최소값은 최대값 보다 작아야 합니다");
-		checkArgument(start.compareTo(end) <= 0, "시작일은 종료일 전이여야 합니다");
+		checkArgument(minPrice <= maxPrice, INVALID_MIN_MAX_VALUE);
+		checkArgument(start.compareTo(end) <= 0, INVALID_START_END_DATE);
 
 		return new SearchAccountBookCmd(categories, minPrice, maxPrice, start.atTime(LocalTime.MIN),
 			end.atTime(LocalTime.MAX), content);

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepository.java
@@ -1,5 +1,8 @@
 package com.prgrms.tenwonmoa.domain.accountbook.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +20,17 @@ public interface ExpenditureRepository extends JpaRepository<Expenditure, Long> 
 	@Query("update Expenditure e set e.categoryName = :categoryName "
 		+ "where e.userCategory.id = :userCategoryId")
 	void updateCategoryName(Long userCategoryId, String categoryName);
+
+	@Query("select SUM(e.amount) from Expenditure e "
+		+ "where e.amount >= :minPrice "
+		+ "and e.amount <= :maxPrice "
+		+ "and e.registerDate >= :startDateTime "
+		+ "and e.registerDate <= :endDateTime "
+		+ "and e.content like CONCAT('%', :content, '%') "
+		+ "and e.userCategory.id in :userCategoryIds "
+		+ "and e.user.id = :userId")
+	Long getSumOfExpenditure(Long minPrice, Long maxPrice,
+		LocalDateTime startDateTime, LocalDateTime endDateTime,
+		String content, List<Long> userCategoryIds,
+		Long userId);
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
@@ -1,5 +1,8 @@
 package com.prgrms.tenwonmoa.domain.accountbook.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -20,4 +23,17 @@ public interface IncomeRepository extends JpaRepository<Income, Long> {
 	@Query("update Income i set i.categoryName = :categoryName "
 		+ "where i.userCategory.id = :userCategoryId")
 	void updateCategoryName(Long userCategoryId, String categoryName);
+
+	@Query("select SUM(i.amount) from Income i "
+		+ "where i.amount >= :minPrice "
+		+ "and i.amount <= :maxPrice "
+		+ "and i.registerDate >= :startDateTime "
+		+ "and i.registerDate <= :endDateTime "
+		+ "and i.content like CONCAT('%', :content, '%') "
+		+ "and i.userCategory.id in :userCategoryIds "
+		+ "and i.user.id = :userId")
+	Long getSumOfIncome(Long minPrice, Long maxPrice,
+		LocalDateTime startDateTime, LocalDateTime endDateTime,
+		String content, List<Long> userCategoryIds, Long userId);
+
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/SearchAccountBookRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/SearchAccountBookRepository.java
@@ -2,9 +2,7 @@ package com.prgrms.tenwonmoa.domain.accountbook.repository;
 
 import java.math.BigInteger;
 import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,7 +23,7 @@ public class SearchAccountBookRepository {
 	private EntityManager em;
 
 	public List<AccountBookItem> searchAccountBook(Long minPrice, Long maxPrice,
-		LocalDate startDate, LocalDate endDate,
+		LocalDateTime startDateTime, LocalDateTime endDateTime,
 		String content, List<Long> userCategoryIds,
 		Long userId, PageCustomRequest pageRequest) {
 
@@ -49,7 +47,7 @@ public class SearchAccountBookRepository {
 
 		Query nativeQuery = em.createNativeQuery(unionQuery);
 		setParameters(nativeQuery, userCategoryIds, userId, content, minPrice,
-			maxPrice, startDate.atTime(LocalTime.MIN), endDate.atTime(LocalTime.MAX));
+			maxPrice, startDateTime, endDateTime);
 		setPagingParam(nativeQuery, pageRequest);
 
 		List<Object[]> results = nativeQuery.getResultList();

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
@@ -11,7 +11,6 @@ import com.prgrms.tenwonmoa.domain.accountbook.dto.AccountBookItem;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.service.SearchAccountBookCmd;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.SearchAccountBookRepository;
-import com.prgrms.tenwonmoa.domain.category.CategoryType;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
 
 import lombok.RequiredArgsConstructor;
@@ -23,7 +22,7 @@ public class SearchAccountBookService {
 
 	private final SearchAccountBookRepository repository;
 
-	public FindAccountBookResponse<AccountBookItem> searchAccountBooks(Long authenticatedId, SearchAccountBookCmd cmd,
+	public FindAccountBookResponse searchAccountBooks(Long authenticatedId, SearchAccountBookCmd cmd,
 		PageCustomRequest pageRequest) {
 
 		checkArgument(cmd.getMinPrice() <= cmd.getMaxPrice(), "최소값은 최대값 보다 작아야 합니다");
@@ -32,23 +31,7 @@ public class SearchAccountBookService {
 		List<AccountBookItem> accountBookItems = repository.searchAccountBook(cmd.getMinPrice(), cmd.getMaxPrice(),
 			cmd.getStart(), cmd.getEnd(), cmd.getContent(), cmd.getCategories(), authenticatedId, pageRequest);
 
-		return calculateSum(accountBookItems, pageRequest);
-	}
-
-	private FindAccountBookResponse<AccountBookItem> calculateSum(List<AccountBookItem> results,
-		PageCustomRequest pageRequest) {
-		Long incomeSum = 0L;
-		Long expenditureSum = 0L;
-
-		for (AccountBookItem item : results) {
-			if (item.getType().equals(CategoryType.INCOME.name())) {
-				incomeSum += item.getAmount();
-			} else {
-				expenditureSum += item.getAmount();
-			}
-		}
-
-		return FindAccountBookResponse.of(pageRequest, results, incomeSum, expenditureSum);
+		return FindAccountBookResponse.of(pageRequest, accountBookItems);
 	}
 
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
@@ -1,7 +1,5 @@
 package com.prgrms.tenwonmoa.domain.accountbook.service;
 
-import static com.google.common.base.Preconditions.*;
-
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -24,9 +22,6 @@ public class SearchAccountBookService {
 
 	public FindAccountBookResponse searchAccountBooks(Long authenticatedId, SearchAccountBookCmd cmd,
 		PageCustomRequest pageRequest) {
-
-		checkArgument(cmd.getMinPrice() <= cmd.getMaxPrice(), "최소값은 최대값 보다 작아야 합니다");
-		checkArgument(cmd.getStart().compareTo(cmd.getEnd()) <= 0, "시작일은 종료일 전이여야 합니다");
 
 		List<AccountBookItem> accountBookItems = repository.searchAccountBook(cmd.getMinPrice(), cmd.getMaxPrice(),
 			cmd.getStart(), cmd.getEnd(), cmd.getContent(), cmd.getCategories(), authenticatedId, pageRequest);

--- a/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
@@ -28,6 +28,10 @@ public enum Message {
 	EXPENDITURE_NOT_FOUND("해당 지출이 존재 하지 않습니다."),
 	EXPENDITURE_NO_AUTHENTICATION("지출에 대한 접근권한이 없습니다."),
 
+	INVALID_MIN_MAX_VALUE("최소값은 최대값 보다 작아야 합니다"),
+
+	INVALID_START_END_DATE("시작일은 종료일 전이여야 합니다"),
+
 	// 수입
 	INVALID_CONTENT_ERR_MSG(MessageFormat.format("내용은 {0}글자 까지만 가능합니다.", CONTENT_MAX)),
 	INVALID_AMOUNT_ERR_MSG(MessageFormat.format("입력 가능 범위는 {0}~{1}입니다.", AMOUNT_MIN, AMOUNT_MAX)),

--- a/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/fixture/RepositoryFixture.java
@@ -17,6 +17,12 @@ import com.prgrms.tenwonmoa.domain.user.User;
 
 public class RepositoryFixture extends RepositoryTest {
 
+	protected final LocalDateTime defaultTime = LocalDateTime.now();
+
+	protected final Long defaultAmount = 1000L;
+
+	protected final String defaultContent = "냉무";
+
 	public User saveRandomUser() {
 		return save(createRandomUser());
 	}
@@ -48,6 +54,20 @@ public class RepositoryFixture extends RepositoryTest {
 		return save(
 			new Expenditure(registerDate, amount, "content", userCategory.getCategoryName(), userCategory.getUser(),
 				userCategory));
+	}
+
+	public void saveExpenditure(LocalDateTime registerDate, Long amount, String content, String categoryName,
+		User user, UserCategory userCategory) {
+		save(new Expenditure(
+			registerDate, amount, content,
+			categoryName, user, userCategory));
+	}
+
+	public void saveIncome(LocalDateTime registerDate, Long amount, String content, String categoryName, User user,
+		UserCategory userCategory) {
+		save(new Income(
+			registerDate, amount, content,
+			categoryName, user, userCategory));
 	}
 
 	public Budget saveBudget(Long amount, YearMonth registerDate, User user, UserCategory userCategory) {

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/SearchAccountBookDocsTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/SearchAccountBookDocsTest.java
@@ -65,12 +65,12 @@ class SearchAccountBookDocsTest {
 	@WithMockCustomUser
 	void 지출_수입_검색() throws Exception {
 		PageCustomRequest pageRequest = new PageCustomRequest(1, 1);
-		FindAccountBookResponse<AccountBookItem> response = of(
+		FindAccountBookResponse response = of(
 			pageRequest,
 			List.of(
 				new AccountBookItem(1L, CategoryType.EXPENDITURE.name(), 10000L, "점심", "식비", LocalDateTime.now()),
-				new AccountBookItem(1L, CategoryType.INCOME.name(), 50000L, "용돈", "용돈", LocalDateTime.now())),
-			50000L, 10000L);
+				new AccountBookItem(1L, CategoryType.INCOME.name(), 50000L, "용돈", "용돈", LocalDateTime.now()))
+		);
 
 		given(accountBookService.searchAccountBooks(anyLong(), any(SearchAccountBookCmd.class), any(
 			PageCustomRequest.class))).willReturn(response);
@@ -100,9 +100,6 @@ class SearchAccountBookDocsTest {
 						parameterWithName("page").description("페이지 번호").optional()
 					),
 					responseFields(
-						fieldWithPath("incomeSum").type(JsonFieldType.NUMBER).description("수입의 총합"),
-						fieldWithPath("expenditureSum").type(JsonFieldType.NUMBER).description("지출의 총합"),
-						fieldWithPath("totalSum").type(JsonFieldType.NUMBER).description("수입,지출 포함 총합"),
 						fieldWithPath("currentPage").type(JsonFieldType.NUMBER).description("현재 페이지"),
 						fieldWithPath("nextPage").type(JsonFieldType.NUMBER).description("다음 페이지"),
 						fieldWithPath("results[]").type(JsonFieldType.ARRAY).description("검색된 지출, 수입 데이터"),

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/SearchAccountBookIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/SearchAccountBookIntegrationTest.java
@@ -76,9 +76,6 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 				.param("content", "")
 				.param("size", "3")
 				.param("page", "1"))
-			.andExpect(jsonPath("$.incomeSum").value(0L))
-			.andExpect(jsonPath("$.expenditureSum").value(5000L))
-			.andExpect(jsonPath("$.totalSum").value(-5000L))
 			.andExpect(jsonPath("$.currentPage").value(1))
 			.andExpect(jsonPath("$.nextPage").isEmpty())
 			.andExpect(jsonPath("$.results", hasSize(1)));
@@ -106,9 +103,6 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 				.param("content", "")
 				.param("size", "3")
 				.param("page", "1"))
-			.andExpect(jsonPath("$.incomeSum").value(10000L))
-			.andExpect(jsonPath("$.expenditureSum").value(5000L))
-			.andExpect(jsonPath("$.totalSum").value(5000L))
 			.andExpect(jsonPath("$.currentPage").value(1))
 			.andExpect(jsonPath("$.nextPage").isEmpty())
 			.andExpect(jsonPath("$.results", hasSize(2)));
@@ -126,9 +120,6 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 		//then
 		mvc.perform(get("/api/v1/account-book/search")
 				.header(HttpHeaders.AUTHORIZATION, accessToken))
-			.andExpect(jsonPath("$.incomeSum").value(10000L))
-			.andExpect(jsonPath("$.expenditureSum").value(5000L))
-			.andExpect(jsonPath("$.totalSum").value(5000L))
 			.andExpect(jsonPath("$.currentPage").value(1))
 			.andExpect(jsonPath("$.nextPage").isEmpty())
 			.andExpect(jsonPath("$.results", hasSize(2)));
@@ -146,9 +137,6 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 		//then
 		mvc.perform(get("/api/v1/account-book/search")
 				.header(HttpHeaders.AUTHORIZATION, accessToken))
-			.andExpect(jsonPath("$.incomeSum").value(10000L))
-			.andExpect(jsonPath("$.expenditureSum").value(5000L))
-			.andExpect(jsonPath("$.totalSum").value(5000L))
 			.andExpect(jsonPath("$.currentPage").value(1))
 			.andExpect(jsonPath("$.nextPage").isEmpty())
 			.andExpect(jsonPath("$.results", hasSize(2)));

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepositoryTest.java
@@ -1,9 +1,13 @@
 package com.prgrms.tenwonmoa.domain.accountbook.repository;
 
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static com.prgrms.tenwonmoa.domain.accountbook.AccountBookConst.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -12,17 +16,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.prgrms.tenwonmoa.common.RepositoryTest;
+import com.prgrms.tenwonmoa.common.fixture.RepositoryFixture;
 import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
 import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.CategoryType;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
 
 @DisplayName("Expenditure(지출) 레포지토리 테스트")
-class ExpenditureRepositoryTest extends RepositoryTest {
+class ExpenditureRepositoryTest extends RepositoryFixture {
 
 	@Autowired
 	private ExpenditureRepository expenditureRepository;
+
+	private List<Long> allUserCategoryIds;
 
 	private User user;
 
@@ -30,11 +37,18 @@ class ExpenditureRepositoryTest extends RepositoryTest {
 
 	private UserCategory userCategory;
 
+	private UserCategory userCategory2;
+
 	@BeforeEach
 	void setup() {
 		user = save(createUser());
-		category = save(createIncomeCategory());
+
+		category = save(new Category("식비", CategoryType.EXPENDITURE));
+		Category category2 = save(new Category("문화생활", CategoryType.EXPENDITURE));
+
 		userCategory = save(new UserCategory(user, category));
+		userCategory2 = save(new UserCategory(user, category2));
+		allUserCategoryIds = new ArrayList<>(List.of(userCategory.getId(), userCategory2.getId()));
 	}
 
 	@Test
@@ -76,18 +90,138 @@ class ExpenditureRepositoryTest extends RepositoryTest {
 			.containsExactlyInAnyOrder("업데이트된카테고리이름", "업데이트된카테고리이름", "업데이트된카테고리이름");
 	}
 
-	private void createExpenditures(int count) {
-		for (int i = 0; i < count; i++) {
-			expenditureRepository.save(
-				new Expenditure(
-					LocalDateTime.now(),
-					10000L + i,
-					"내용" + i,
-					category.getName(),
-					user,
-					userCategory
-				)
-			);
-		}
+	@Test
+	void 금액조건을_만족하는_지출의_합계_조회() {
+		//given
+		saveExpenditure(defaultTime, 1000L, defaultContent, category.getName(), user,
+			userCategory);
+		saveExpenditure(defaultTime, 10000L, defaultContent, category.getName(), user,
+			userCategory);
+		saveExpenditure(defaultTime, 20000L, defaultContent, category.getName(), user,
+			userCategory);
+		saveExpenditure(defaultTime, 50000L, defaultContent, category.getName(), user,
+			userCategory);
+
+		//when
+		Long sum = expenditureRepository.getSumOfExpenditure(
+			1000L, 50000L, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent, allUserCategoryIds, user.getId());
+
+		//then
+		assertThat(sum).isEqualTo(81000L);
+	}
+
+	@Test
+	void 내용_조건을_만족하는_지출의_합계_조회() {
+		//given
+		saveExpenditure(defaultTime, defaultAmount, "점심식사",
+			category.getName(), user, userCategory);
+
+		saveExpenditure(defaultTime, defaultAmount, "영화",
+			category.getName(), user, userCategory);
+
+		saveExpenditure(defaultTime, defaultAmount, "영화관람",
+			category.getName(), user, userCategory);
+
+		saveExpenditure(defaultTime, defaultAmount, "문화 영화 관람",
+			category.getName(), user, userCategory);
+
+		//when
+		Long sum = expenditureRepository.getSumOfExpenditure(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), "영화", allUserCategoryIds,
+			user.getId());
+
+		//then
+		assertThat(sum).isEqualTo(3 * defaultAmount);
+	}
+
+	@Test
+	void 등록날짜_조건을_만족하는_지출의_합계_조회() {
+		//given
+		LocalDateTime latestDate = LocalDateTime.now().minusDays(1);
+		LocalDateTime secondDate = LocalDateTime.now().minusDays(2);
+		LocalDateTime thirdDate = LocalDateTime.now().minusDays(5);
+		LocalDateTime fourthDate = LocalDateTime.now().minusDays(10);
+
+		saveExpenditure(latestDate, defaultAmount, defaultContent, category.getName(), user,
+			userCategory);
+		saveExpenditure(secondDate, defaultAmount, defaultContent, category.getName(), user,
+			userCategory);
+		saveExpenditure(thirdDate, defaultAmount, defaultContent, category.getName(), user,
+			userCategory);
+		saveExpenditure(fourthDate, defaultAmount, defaultContent, category.getName(), user,
+			userCategory);
+
+		//when
+		Long sum = expenditureRepository.getSumOfExpenditure(
+			AMOUNT_MIN, AMOUNT_MAX, LocalDate.now().minusDays(6).atTime(LocalTime.MIN),
+			LocalDate.now().atTime(LocalTime.MAX), defaultContent, allUserCategoryIds, user.getId());
+
+		//then
+		assertThat(sum).isEqualTo(3 * defaultAmount);
+	}
+
+	@Test
+	void 카테고리_조건을_만족하는_지출_합계_조회() {
+		//given
+
+		// userCategory
+		saveExpenditure(defaultTime, defaultAmount, defaultContent, userCategory.getCategoryName(), user,
+			userCategory);
+
+		// userCategory2
+		saveExpenditure(defaultTime, defaultAmount, defaultContent, userCategory2.getCategoryName(), user,
+			userCategory2);
+
+		saveExpenditure(defaultTime, defaultAmount, defaultContent, userCategory2.getCategoryName(), user,
+			userCategory2);
+
+		//when
+		Long userCategorySum = expenditureRepository.getSumOfExpenditure(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent,
+			List.of(userCategory.getId()), user.getId());
+
+		Long userCategorySum2 = expenditureRepository.getSumOfExpenditure(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent,
+			List.of(userCategory2.getId()), user.getId());
+
+		//then
+		assertThat(userCategorySum).isEqualTo(defaultAmount);
+		assertThat(userCategorySum2).isEqualTo(2 * defaultAmount);
+	}
+
+	@Test
+	void 유저_아이디_조건을_만족하는_지출의_합계_조회() {
+		//given
+		User otherUser = save(createAnotherUser());
+		UserCategory otherUserCategory = save(createUserCategory(otherUser, category));
+
+		allUserCategoryIds.add(otherUserCategory.getId());
+
+		// user
+		saveExpenditure(defaultTime, 10000L, defaultContent,
+			userCategory.getCategoryName(), user, userCategory);
+
+		// other user
+		saveExpenditure(defaultTime, 20000L, defaultContent,
+			otherUserCategory.getCategoryName(), otherUser, otherUserCategory);
+
+		//when
+		Long sum = expenditureRepository.getSumOfExpenditure(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent,
+			allUserCategoryIds, user.getId());
+
+		Long otherUserSum = expenditureRepository.getSumOfExpenditure(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent,
+			allUserCategoryIds, otherUser.getId());
+
+		//then
+		assertThat(sum).isEqualTo(10000L);
+		assertThat(otherUserSum).isEqualTo(20000L);
 	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepositoryTest.java
@@ -1,8 +1,13 @@
 package com.prgrms.tenwonmoa.domain.accountbook.repository;
 
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static com.prgrms.tenwonmoa.domain.accountbook.AccountBookConst.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -15,22 +20,37 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.prgrms.tenwonmoa.common.fixture.RepositoryFixture;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.CategoryType;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.user.User;
 
 @DisplayName("수입 Repository 테스트")
 class IncomeRepositoryTest extends RepositoryFixture {
 
+	private List<Long> allUserCategoryIds;
+
 	@Autowired
 	private IncomeRepository incomeRepository;
 
+	private User user;
+
+	private Category category;
+
 	private UserCategory userCategory;
+
+	private UserCategory userCategory2;
 
 	@BeforeEach
 	void setup() {
-		User user = save(createUser());
-		Category category = save(createIncomeCategory());
+		user = save(createUser());
+
+		category = save(new Category("월급", CategoryType.INCOME));
+		Category category2 = save(new Category("용돈", CategoryType.INCOME));
+
 		userCategory = save(createUserCategory(user, category));
+		userCategory2 = save(createUserCategory(user, category2));
+
+		allUserCategoryIds = new ArrayList<>(List.of(userCategory.getId(), userCategory2.getId()));
 	}
 
 	@Test
@@ -83,4 +103,140 @@ class IncomeRepositoryTest extends RepositoryFixture {
 		Optional<Income> findIncome = incomeRepository.findById(incomeId);
 		assertThat(findIncome).isEmpty();
 	}
+
+	@Test
+	void 금액조건을_만족하는_수입의_합계_조회() {
+		//given
+		saveIncome(defaultTime, 1000L, defaultContent, category.getName(), user,
+			userCategory);
+		saveIncome(defaultTime, 10000L, defaultContent, category.getName(), user,
+			userCategory);
+		saveIncome(defaultTime, 20000L, defaultContent, category.getName(), user,
+			userCategory);
+		saveIncome(defaultTime, 50000L, defaultContent, category.getName(), user,
+			userCategory);
+
+		//when
+		Long sum = incomeRepository.getSumOfIncome(
+			1000L, 50000L, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent, allUserCategoryIds, user.getId());
+
+		//then
+		assertThat(sum).isEqualTo(81000L);
+	}
+
+	@Test
+	void 내용_조건을_만족하는_수입의_합계_조회() {
+		//given
+		saveIncome(defaultTime, defaultAmount, "점심식사",
+			category.getName(), user, userCategory);
+
+		saveIncome(defaultTime, defaultAmount, "영화",
+			category.getName(), user, userCategory);
+
+		saveIncome(defaultTime, defaultAmount, "영화관람",
+			category.getName(), user, userCategory);
+
+		saveIncome(defaultTime, defaultAmount, "문화 영화 관람",
+			category.getName(), user, userCategory);
+
+		//when
+		Long sum = incomeRepository.getSumOfIncome(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), "영화", allUserCategoryIds,
+			user.getId());
+
+		//then
+		assertThat(sum).isEqualTo(3 * defaultAmount);
+	}
+
+	@Test
+	void 등록날짜_조건을_만족하는_수입의_합계_조회() {
+		//given
+		LocalDateTime latestDate = LocalDateTime.now().minusDays(1);
+		LocalDateTime secondDate = LocalDateTime.now().minusDays(2);
+		LocalDateTime thirdDate = LocalDateTime.now().minusDays(5);
+		LocalDateTime fourthDate = LocalDateTime.now().minusDays(10);
+
+		saveIncome(latestDate, defaultAmount, defaultContent, category.getName(), user,
+			userCategory);
+		saveIncome(secondDate, defaultAmount, defaultContent, category.getName(), user,
+			userCategory);
+		saveIncome(thirdDate, defaultAmount, defaultContent, category.getName(), user,
+			userCategory);
+		saveIncome(fourthDate, defaultAmount, defaultContent, category.getName(), user,
+			userCategory);
+
+		//when
+		Long sum = incomeRepository.getSumOfIncome(
+			AMOUNT_MIN, AMOUNT_MAX, LocalDate.now().minusDays(6).atTime(LocalTime.MIN),
+			LocalDate.now().atTime(LocalTime.MAX), defaultContent, allUserCategoryIds, user.getId());
+
+		//then
+		assertThat(sum).isEqualTo(3 * defaultAmount);
+	}
+
+	@Test
+	void 카테고리_조건을_만족하는_수입_합계_조회() {
+		//given
+
+		// userCategory
+		saveIncome(defaultTime, defaultAmount, defaultContent, userCategory.getCategoryName(), user,
+			userCategory);
+
+		// userCategory2
+		saveIncome(defaultTime, defaultAmount, defaultContent, userCategory2.getCategoryName(), user,
+			userCategory2);
+
+		saveIncome(defaultTime, defaultAmount, defaultContent, userCategory2.getCategoryName(), user,
+			userCategory2);
+
+		//when
+		Long userCategorySum = incomeRepository.getSumOfIncome(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent,
+			List.of(userCategory.getId()), user.getId());
+
+		Long userCategorySum2 = incomeRepository.getSumOfIncome(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent,
+			List.of(userCategory2.getId()), user.getId());
+
+		//then
+		assertThat(userCategorySum).isEqualTo(defaultAmount);
+		assertThat(userCategorySum2).isEqualTo(2 * defaultAmount);
+	}
+
+	@Test
+	void 유저_아이디_조건을_만족하는_수입의_합계_조회() {
+		//given
+		User otherUser = save(createAnotherUser());
+		UserCategory otherUserCategory = save(createUserCategory(otherUser, category));
+
+		allUserCategoryIds.add(otherUserCategory.getId());
+
+		// user
+		saveIncome(defaultTime, 10000L, defaultContent,
+			userCategory.getCategoryName(), user, userCategory);
+
+		// other user
+		saveIncome(defaultTime, 20000L, defaultContent,
+			otherUserCategory.getCategoryName(), otherUser, otherUserCategory);
+
+		//when
+		Long sum = incomeRepository.getSumOfIncome(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent,
+			allUserCategoryIds, user.getId());
+
+		Long otherUserSum = incomeRepository.getSumOfIncome(
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent,
+			allUserCategoryIds, otherUser.getId());
+
+		//then
+		assertThat(sum).isEqualTo(10000L);
+		assertThat(otherUserSum).isEqualTo(20000L);
+	}
+
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/SearchAccountBookRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/SearchAccountBookRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -75,11 +76,13 @@ class SearchAccountBookRepositoryTest extends RepositoryFixture {
 
 		//when
 		List<AccountBookItem> items = repository.searchAccountBook(
-			1000L, 50000L, LEFT_MOST_REGISTER_DATE, RIGHT_MOST_REGISTER_DATE,
+			1000L, 50000L, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX),
 			defaultContent, allUserCategoryIds, user.getId(), new PageCustomRequest(1, 10));
 
 		List<AccountBookItem> items2 = repository.searchAccountBook(
-			50000L, 100000L, LEFT_MOST_REGISTER_DATE, RIGHT_MOST_REGISTER_DATE,
+			50000L, 100000L, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX),
 			defaultContent, allUserCategoryIds, user.getId(), new PageCustomRequest(1, 10));
 
 		//then
@@ -110,8 +113,8 @@ class SearchAccountBookRepositoryTest extends RepositoryFixture {
 
 		//when
 		List<AccountBookItem> items = repository.searchAccountBook(
-			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE,
-			RIGHT_MOST_REGISTER_DATE, "영화", allUserCategoryIds, user.getId(),
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), "영화", allUserCategoryIds, user.getId(),
 			new PageCustomRequest(1, 10));
 
 		//then
@@ -138,14 +141,14 @@ class SearchAccountBookRepositoryTest extends RepositoryFixture {
 
 		//when
 		List<AccountBookItem> items = repository.searchAccountBook(
-			AMOUNT_MIN, AMOUNT_MAX, LocalDate.now().minusDays(6),
-			LocalDate.now(), defaultContent, allUserCategoryIds, user.getId(),
+			AMOUNT_MIN, AMOUNT_MAX, LocalDate.now().minusDays(6).atTime(LocalTime.MIN),
+			LocalDate.now().atTime(LocalTime.MAX), defaultContent, allUserCategoryIds, user.getId(),
 			new PageCustomRequest(1, 10));
 
 		List<AccountBookItem> items2 = repository.searchAccountBook(
-			AMOUNT_MIN, AMOUNT_MAX, LocalDate.now().minusDays(10),
-			LocalDate.now().minusDays(4), defaultContent, allUserCategoryIds, user.getId(),
-			new PageCustomRequest(1, 10));
+			AMOUNT_MIN, AMOUNT_MAX, LocalDate.now().minusDays(10).atTime(LocalTime.MIN),
+			LocalDate.now().minusDays(4).atTime(LocalTime.MAX), defaultContent,
+			allUserCategoryIds, user.getId(), new PageCustomRequest(1, 10));
 
 		//then
 		assertThat(items).extracting(AccountBookItem::getRegisterTime)
@@ -179,18 +182,21 @@ class SearchAccountBookRepositoryTest extends RepositoryFixture {
 
 		//when
 		List<AccountBookItem> expenditureUserCategoryItems = repository.searchAccountBook(
-			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE,
-			RIGHT_MOST_REGISTER_DATE, defaultContent, List.of(expenditureUserCategory.getId()), user.getId(),
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent, List.of(expenditureUserCategory.getId()),
+			user.getId(),
 			new PageCustomRequest(1, 10));
 
 		List<AccountBookItem> expenditureUserCategory2Items = repository.searchAccountBook(
-			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE,
-			RIGHT_MOST_REGISTER_DATE, defaultContent, List.of(expenditureUserCategory2.getId()), user.getId(),
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent, List.of(expenditureUserCategory2.getId()),
+			user.getId(),
 			new PageCustomRequest(1, 10));
 
 		List<AccountBookItem> incomeUserCategoryItems = repository.searchAccountBook(
-			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE,
-			RIGHT_MOST_REGISTER_DATE, defaultContent, List.of(incomeUserCategory.getId()), user.getId(),
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent, List.of(incomeUserCategory.getId()),
+			user.getId(),
 			new PageCustomRequest(1, 10));
 
 		//then
@@ -228,13 +234,13 @@ class SearchAccountBookRepositoryTest extends RepositoryFixture {
 
 		//when
 		List<AccountBookItem> userItems = repository.searchAccountBook(
-			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE,
-			RIGHT_MOST_REGISTER_DATE, defaultContent, allUserCategoryIds, user.getId(),
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent, allUserCategoryIds, user.getId(),
 			new PageCustomRequest(1, 10));
 
 		List<AccountBookItem> otherUserItems = repository.searchAccountBook(
-			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE,
-			RIGHT_MOST_REGISTER_DATE, defaultContent, allUserCategoryIds, otherUser.getId(),
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), defaultContent, allUserCategoryIds, otherUser.getId(),
 			new PageCustomRequest(1, 10));
 
 		//then
@@ -259,8 +265,8 @@ class SearchAccountBookRepositoryTest extends RepositoryFixture {
 
 		//when
 		List<AccountBookItem> items = repository.searchAccountBook(
-			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE,
-			RIGHT_MOST_REGISTER_DATE, "", allUserCategoryIds, user.getId(),
+			AMOUNT_MIN, AMOUNT_MAX, LEFT_MOST_REGISTER_DATE.atTime(LocalTime.MIN),
+			RIGHT_MOST_REGISTER_DATE.atTime(LocalTime.MAX), "", allUserCategoryIds, user.getId(),
 			new PageCustomRequest(1, 10));
 
 		//then

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/SearchAccountBookRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/repository/SearchAccountBookRepositoryTest.java
@@ -14,9 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.prgrms.tenwonmoa.common.RepositoryTest;
-import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
-import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.common.fixture.RepositoryFixture;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.AccountBookItem;
 import com.prgrms.tenwonmoa.domain.category.Category;
 import com.prgrms.tenwonmoa.domain.category.CategoryType;
@@ -25,13 +23,7 @@ import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
 import com.prgrms.tenwonmoa.domain.user.User;
 
 @DisplayName("가계부 검색 리포지토리 테스트")
-class SearchAccountBookRepositoryTest extends RepositoryTest {
-
-	private final LocalDateTime defaultTime = LocalDateTime.now();
-
-	private final Long defaultAmount = 1000L;
-
-	private final String defaultContent = "냉무";
+class SearchAccountBookRepositoryTest extends RepositoryFixture {
 
 	private List<Long> allUserCategoryIds;
 
@@ -66,20 +58,6 @@ class SearchAccountBookRepositoryTest extends RepositoryTest {
 
 		allUserCategoryIds = new ArrayList<>(List.of(expenditureUserCategory.getId(), expenditureUserCategory2.getId(),
 			incomeUserCategory.getId()));
-	}
-
-	private void saveExpenditure(LocalDateTime registerDate, Long amount, String content, String categoryName,
-		User user, UserCategory userCategory) {
-		save(new Expenditure(
-			registerDate, amount, content,
-			categoryName, user, userCategory));
-	}
-
-	private void saveIncome(LocalDateTime registerDate, Long amount, String content, String categoryName, User user,
-		UserCategory userCategory) {
-		save(new Income(
-			registerDate, amount, content,
-			categoryName, user, userCategory));
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookServiceTest.java
@@ -70,15 +70,16 @@ class SearchAccountBookServiceTest {
 			.willReturn(List.of(latestIncome, secondExpenditure, thirdExpenditure));
 
 		//when
-		FindAccountBookResponse<AccountBookItem> findAccountBookResponse =
+		FindAccountBookResponse findAccountBookResponse =
 			accountBookService.searchAccountBooks(userId, cmd, pageRequest);
 
 		//then
-		assertThat(findAccountBookResponse.getIncomeSum()).isEqualTo(latestIncome.getAmount());
-		assertThat(findAccountBookResponse.getExpenditureSum())
-			.isEqualTo(secondExpenditure.getAmount() + thirdExpenditure.getAmount());
-		assertThat(findAccountBookResponse.getTotalSum())
-			.isEqualTo(latestIncome.getAmount() - secondExpenditure.getAmount() - thirdExpenditure.getAmount());
+		assertThat(findAccountBookResponse.getResults()).hasSize(3);
+		assertThat(findAccountBookResponse.getResults()).extracting(AccountBookItem::getId)
+			.containsExactlyInAnyOrder(
+				latestIncome.getId(),
+				secondExpenditure.getId(),
+				thirdExpenditure.getId());
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookServiceTest.java
@@ -5,7 +5,6 @@ import static com.prgrms.tenwonmoa.domain.accountbook.AccountBookConst.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -80,33 +79,5 @@ class SearchAccountBookServiceTest {
 				latestIncome.getId(),
 				secondExpenditure.getId(),
 				thirdExpenditure.getId());
-	}
-
-	@Test
-	void 금액_최소값이_최대값보다_크면_검색_실패() {
-		Long minPrice = AMOUNT_MAX;
-		Long maxPrice = AMOUNT_MIN;
-
-		SearchAccountBookCmd cmd = SearchAccountBookCmd.of("1,2,3", minPrice, maxPrice,
-			LEFT_MOST_REGISTER_DATE, RIGHT_MOST_REGISTER_DATE, "");
-		PageCustomRequest pageRequest = new PageCustomRequest(1, 3);
-
-		assertThatIllegalArgumentException().isThrownBy(
-			() -> accountBookService.searchAccountBooks(userId, cmd, pageRequest)
-		);
-	}
-
-	@Test
-	void 시작일이_종료일보다_뒤이면_검색_실패() {
-		LocalDate start = RIGHT_MOST_REGISTER_DATE;
-		LocalDate end = LEFT_MOST_REGISTER_DATE;
-
-		SearchAccountBookCmd cmd = SearchAccountBookCmd.of("1,2,3", AMOUNT_MIN, AMOUNT_MAX,
-			start, end, "");
-		PageCustomRequest pageRequest = new PageCustomRequest(1, 3);
-
-		assertThatIllegalArgumentException().isThrownBy(
-			() -> accountBookService.searchAccountBooks(userId, cmd, pageRequest)
-		);
 	}
 }


### PR DESCRIPTION
## 개요

- 검색 합계 API를 위한 리포지토리 & 테스트

## 추가기능

- 검색 조건의 지출, 수입의 합계 가져오는 쿼리

## 변경사항(Optional)
- 원래 검색 API 에서 반환하던 합계값(incomeSum, expenditureSum, totalSum) 제거
- FindAccountBookResponse generic 제거

- service layer에서 입력 유효성 검증하던것 Cmd 객체 안으로 옮김
- Cmd 객체(서비스 레이어 모델) 안에서 LocalDate -> LocalDateTime 으로 바꾸어서 저장함(어차피 repository에서 필요한건 LocalDateTime이라서)
  - Repository에서 LocalDate를 받지않고 LocalDateTime 받도록 수정
- 리포지토리 테스트에서 공통 부분 RepositoryFixture로 이동(saveExpenditure, saveIncome, defaultAmount, defaultContent ..)

## 기타
- IncomeRepositoryTest와 ExpenditureRepositoryTest는 길어보이는데 다 사실 똑같은 로직 테스트입니다. SearchAccountBookRepository의 로직 테스트와 똑같아요
- 빠른 반영이 필요해서 3분 다 reviewer로 지정할게요!