### PR TITLE
[#216] 회원 탈퇴

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/ExpenditureRepository.java
@@ -17,4 +17,9 @@ public interface ExpenditureRepository extends JpaRepository<Expenditure, Long> 
 	@Query("update Expenditure e set e.categoryName = :categoryName "
 		+ "where e.userCategory.id = :userCategoryId")
 	void updateCategoryName(Long userCategoryId, String categoryName);
+
+	@Modifying
+	@Query("delete from Expenditure e where e.user.id = :userId")
+	void deleteAllByUserIdInQuery(Long userId);
+
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/repository/IncomeRepository.java
@@ -20,4 +20,8 @@ public interface IncomeRepository extends JpaRepository<Income, Long> {
 	@Query("update Income i set i.categoryName = :categoryName "
 		+ "where i.userCategory.id = :userCategoryId")
 	void updateCategoryName(Long userCategoryId, String categoryName);
+
+	@Modifying
+	@Query("delete from Income i where i.user.id = :userId")
+	void deleteAllByUserIdInQuery(Long userId);
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetRepository.java
@@ -4,9 +4,15 @@ import java.time.YearMonth;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.prgrms.tenwonmoa.domain.budget.Budget;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
 	Optional<Budget> findByUserCategoryIdAndRegisterDate(Long userCategoryId, YearMonth registerDate);
+
+	@Modifying
+	@Query("delete from Budget b where b.user.id = :userId")
+	void deleteAllByUserIdInQuery(Long userId);
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/category/repository/UserCategoryRepository.java
@@ -3,6 +3,7 @@ package com.prgrms.tenwonmoa.domain.category.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -19,4 +20,8 @@ public interface UserCategoryRepository extends JpaRepository<UserCategory, Long
 	List<UserCategory> findByUserIdAndCategoryType(Long userId, CategoryType categoryType);
 
 	List<UserCategory> findByUserId(Long userId);
+
+	@Modifying
+	@Query("delete from UserCategory uc where uc.user.id = :userId")
+	void deleteAllByUserIdInQuery(Long userId);
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -57,6 +58,12 @@ public class UserController {
 	public ResponseEntity<Void> logout(@AuthenticationPrincipal Long userId,
 		@RequestHeader("Authorization") String accessToken) {
 		userService.logout(userId, accessToken.substring(JwtConst.BEARER_PREFIX.length()));
+		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping("/delete")
+	public ResponseEntity<Void> delete(@AuthenticationPrincipal Long userId) {
+		userService.deleteUser(userId);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserDeleteService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserDeleteService.java
@@ -1,0 +1,33 @@
+package com.prgrms.tenwonmoa.domain.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+import com.prgrms.tenwonmoa.domain.budget.repository.BudgetRepository;
+import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
+import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDeleteService {
+
+	private final IncomeRepository incomeRepository;
+	private final ExpenditureRepository expenditureRepository;
+	private final BudgetRepository budgetRepository;
+	private final UserCategoryRepository userCategoryRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void deleteUserData(Long userId) {
+		incomeRepository.deleteAllByUserIdInQuery(userId);
+		expenditureRepository.deleteAllByUserIdInQuery(userId);
+		budgetRepository.deleteAllByUserIdInQuery(userId);
+		userCategoryRepository.deleteAllByUserIdInQuery(userId);
+		userRepository.deleteById(userId);
+	}
+
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
@@ -26,6 +26,8 @@ public class UserService {
 	private final PasswordEncoder passwordEncoder;
 	private final CreateDefaultUserCategoryService createDefaultUserCategoryService;
 	private final JwtService jwtService;
+	private final UserDeleteService userDeleteService;
+
 
 	public User findById(Long userId) {
 		return userRepository.findById(userId)
@@ -69,6 +71,14 @@ public class UserService {
 		User user = this.findById(userId);
 
 		jwtService.saveLogoutAccessToken(user.getEmail(), accessToken);
+		jwtService.deleteRefreshToken(user.getEmail());
+	}
+
+	@Transactional
+	public void deleteUser(Long userId) {
+		User user = this.findById(userId);
+
+		userDeleteService.deleteUserData(userId);
 		jwtService.deleteRefreshToken(user.getEmail());
 	}
 

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserDeleteServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserDeleteServiceTest.java
@@ -1,0 +1,189 @@
+package com.prgrms.tenwonmoa.domain.user.service;
+
+import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.prgrms.tenwonmoa.common.RepositoryTest;
+import com.prgrms.tenwonmoa.domain.accountbook.Expenditure;
+import com.prgrms.tenwonmoa.domain.accountbook.Income;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
+import com.prgrms.tenwonmoa.domain.budget.Budget;
+import com.prgrms.tenwonmoa.domain.budget.repository.BudgetRepository;
+import com.prgrms.tenwonmoa.domain.category.Category;
+import com.prgrms.tenwonmoa.domain.category.UserCategory;
+import com.prgrms.tenwonmoa.domain.category.repository.UserCategoryRepository;
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
+
+@DisplayName("UserDeleteService 테스트")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+@Import(UserDeleteService.class)
+class UserDeleteServiceTest extends RepositoryTest {
+
+	@Autowired
+	private IncomeRepository incomeRepository;
+
+	@Autowired
+	private ExpenditureRepository expenditureRepository;
+
+	@Autowired
+	private BudgetRepository budgetRepository;
+
+	@Autowired
+	private UserCategoryRepository userCategoryRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private UserDeleteService userDeleteService;
+
+	private User user;
+
+	private Category incomeCategory;
+	private Category expenditureCategory;
+
+	private UserCategory userCategory;
+
+	@BeforeEach
+	void setup() {
+		user = save(createUser());
+		incomeCategory = save(createIncomeCategory());
+		expenditureCategory = save(createExpenditureCategory());
+		userCategory = save(new UserCategory(user, incomeCategory));
+		userCategory = save(new UserCategory(user, expenditureCategory));
+	}
+
+	@Test
+	void 데이터와_유저_삭제() {
+		// given
+		createIncomes(10, user, userCategory);
+		createExpenditures(20, user, userCategory);
+		createBudgets(5, user, userCategory);
+
+		// when
+		userDeleteService.deleteUserData(user.getId());
+
+		List<Income> incomes = incomeRepository.findAll();
+		List<Expenditure> expenditures = expenditureRepository.findAll();
+		List<UserCategory> userCategories = userCategoryRepository.findAll();
+		List<Budget> budgets = budgetRepository.findAll();
+		List<User> users = userRepository.findAll();
+
+		// then
+		assertAll(
+			() -> assertThat(incomes).hasSize(0),
+			() -> assertThat(expenditures).hasSize(0),
+			() -> assertThat(userCategories).hasSize(0),
+			() -> assertThat(budgets).hasSize(0),
+			() -> assertThat(users).hasSize(0)
+		);
+	}
+
+	@Test
+	void 데이터가_없는_유저_삭제() {
+		// given when
+		userDeleteService.deleteUserData(user.getId());
+
+		List<Income> incomes = incomeRepository.findAll();
+		List<Expenditure> expenditures = expenditureRepository.findAll();
+		List<UserCategory> userCategories = userCategoryRepository.findAll();
+		List<Budget> budgets = budgetRepository.findAll();
+		List<User> users = userRepository.findAll();
+
+		// then
+		assertAll(
+			() -> assertThat(incomes).hasSize(0),
+			() -> assertThat(expenditures).hasSize(0),
+			() -> assertThat(userCategories).hasSize(0),
+			() -> assertThat(budgets).hasSize(0),
+			() -> assertThat(users).hasSize(0)
+		);
+	}
+
+	@Test
+	void 다른_유저의_데이터는_삭제_안함() {
+		// given
+		User user2 = save(new User("test2@test.com", "test1234", "testuser2"));
+		save(new UserCategory(user2, incomeCategory));
+		UserCategory user2Category = save(new UserCategory(user2, expenditureCategory));
+		createIncomes(10, user2, user2Category);
+		createExpenditures(20, user2, user2Category);
+		createBudgets(5, user2, user2Category);
+
+		// when
+		userDeleteService.deleteUserData(user.getId());
+
+		List<Income> incomes = incomeRepository.findAll();
+		List<Expenditure> expenditures = expenditureRepository.findAll();
+		List<UserCategory> userCategories = userCategoryRepository.findAll();
+		List<Budget> budgets = budgetRepository.findAll();
+		List<User> users = userRepository.findAll();
+
+		// then
+		assertAll(
+			() -> assertThat(incomes).hasSize(10),
+			() -> assertThat(expenditures).hasSize(20),
+			() -> assertThat(userCategories).hasSize(2),
+			() -> assertThat(budgets).hasSize(5),
+			() -> assertThat(users).hasSize(1)
+		);
+	}
+
+	private void createExpenditures(int count, User user, UserCategory userCategory) {
+		for (int i = 0; i < count; i++) {
+			expenditureRepository.save(
+				new Expenditure(
+					LocalDateTime.now(),
+					10000L + i,
+					"내용" + i,
+					expenditureCategory.getName(),
+					user,
+					userCategory
+				)
+			);
+		}
+	}
+
+	private void createIncomes(int count, User user, UserCategory userCategory) {
+		for (int i = 0; i < count; i++) {
+			incomeRepository.save(
+				new Income(
+					LocalDateTime.now(),
+					10000L + i,
+					"내용" + i,
+					incomeCategory.getName(),
+					user,
+					userCategory
+				)
+			);
+		}
+	}
+
+	private void createBudgets(int count, User user, UserCategory userCategory) {
+		for (int i = 0; i < count; i++) {
+			budgetRepository.save(
+				new Budget(
+					100L,
+					YearMonth.now(),
+					user,
+					userCategory));
+		}
+	}
+
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/user/service/UserServiceTest.java
@@ -40,6 +40,9 @@ class UserServiceTest {
 	@Mock
 	private JwtService jwtService;
 
+	@Mock
+	private UserDeleteService userDeleteService;
+
 	@InjectMocks
 	private UserService userService;
 
@@ -150,6 +153,20 @@ class UserServiceTest {
 		userService.logout(user.getId(), accessToken);
 
 		verify(jwtService).saveLogoutAccessToken(user.getEmail(), accessToken);
+		verify(jwtService).deleteRefreshToken(user.getEmail());
+	}
+
+	@Test
+	void 유저_삭제_성공() {
+		User user = createUser();
+
+		given(userRepository.findById(any())).willReturn(Optional.of(user));
+		doNothing().when(userDeleteService).deleteUserData(any());
+		doNothing().when(jwtService).deleteRefreshToken(any(String.class));
+
+		userService.deleteUser(user.getId());
+
+		verify(userDeleteService).deleteUserData(user.getId());
 		verify(jwtService).deleteRefreshToken(user.getEmail());
 	}
 


### PR DESCRIPTION
## 개요

- 회원 탈퇴 기능 추가

## 추가기능

- 회원 탈퇴 기능

## 변경사항(Optional)

- ExpenditureRepo, IncomeRepo, BudgetRepo, UserCategoryRepo에 userId로 delete 하는 메소드 추가
- JwtAuthenticationFilter에서 토큰의 email을 꺼내와 탈퇴한 회원인지 확인 (DB에 없는지 확인)
 
## 사용방법(Optional)
 - 삭제 요청
1. ExpenditureRepo, IncomeRepo, BudgetRepo, UserCategoryRepo에서 user의 데이터 삭제
2. refresh-token 삭제


