### PR TITLE
[#209] 예산 컨트롤러 테스트 작성

### DIFF
--- a/docs/budget.adoc
+++ b/docs/budget.adoc
@@ -24,3 +24,21 @@ include::{snippets}/budget-findBy-registerDate/http-request.adoc[]
 include::{snippets}/budget-findBy-registerDate/http-response.adoc[]
 Response Fields
 include::{snippets}/budget-findBy-registerDate/response-fields.adoc[]
+
+=== 예산 통계 조회 - 월 별
+
+.Request
+include::{snippets}/budget_statistics-month/http-request.adoc[]
+.Response
+include::{snippets}/budget_statistics-month/http-response.adoc[]
+Response Fields
+include::{snippets}/budget_statistics-month/response-fields.adoc[]
+
+=== 예산 통계 조회 - 연 별
+
+.Request
+include::{snippets}/budget_statistics-year/http-request.adoc[]
+.Response
+include::{snippets}/budget_statistics-year/http-response.adoc[]
+Response Fields
+include::{snippets}/budget_statistics-year/response-fields.adoc[]

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetQueryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetQueryRepository.java
@@ -39,7 +39,7 @@ public class BudgetQueryRepository {
 			))
 			.from(budget)
 			.rightJoin(budget.userCategory, userCategory)
-			.on(budget.registerDate.eq(registerDate))
+			.on(budget.registerDate.eq(registerDate), budget.user.id.eq(userId))
 			.where(userCategory.user.id.eq(userId))
 			.orderBy(AMOUNT.desc())
 			.fetch();

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetQueryRepository.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetQueryRepository.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 
 import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetByRegisterDate;
 import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetData;
+import com.prgrms.tenwonmoa.domain.category.CategoryType;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -40,7 +41,8 @@ public class BudgetQueryRepository {
 			.from(budget)
 			.rightJoin(budget.userCategory, userCategory)
 			.on(budget.registerDate.eq(registerDate), budget.user.id.eq(userId))
-			.where(userCategory.user.id.eq(userId))
+			.where(userCategory.user.id.eq(userId),
+				userCategory.category.categoryType.eq(CategoryType.EXPENDITURE))
 			.orderBy(AMOUNT.desc())
 			.fetch();
 	}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalService.java
@@ -1,7 +1,5 @@
 package com.prgrms.tenwonmoa.domain.budget.service;
 
-import static com.google.common.base.Preconditions.*;
-
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +87,9 @@ public class BudgetTotalService {
 
 	private Long calcPercent(Long amount, Long expenditure) {
 		Long percent = 0L;
-		checkArgument(amount > AMOUNT_MIN, INVALID_AMOUNT_EXP_MSG);
+		if (amount <= AMOUNT_MIN) {
+			return expenditure;
+		}
 		if (expenditure > AMOUNT_MIN) {
 			double doubleData = ((double)expenditure / amount) * PERCENTAGE;
 			percent = (long)Math.floor(doubleData);

--- a/src/main/resources/db/migration/V1_0_5__budget_table_change.sql
+++ b/src/main/resources/db/migration/V1_0_5__budget_table_change.sql
@@ -1,0 +1,10 @@
+alter table budget drop column start_time;
+alter table budget drop column end_time;
+
+alter table budget modify amount bigint not null;
+alter table budget modify register_date mediumint not null;
+alter table budget modify user_id bigint not null;
+alter table budget modify user_category_id bigint not null;
+
+alter table budget add constraint fk_budget_user foreign key (user_id) references user (id);
+alter table budget add constraint fk_budget_user_category foreign key (user_category_id) references user_category (id);

--- a/src/main/resources/db/migration/V1_0_5__budget_table_change.sql
+++ b/src/main/resources/db/migration/V1_0_5__budget_table_change.sql
@@ -1,10 +1,10 @@
 alter table budget drop column start_time;
 alter table budget drop column end_time;
 
-alter table budget modify amount bigint not null;
-alter table budget modify register_date mediumint not null;
-alter table budget modify user_id bigint not null;
-alter table budget modify user_category_id bigint not null;
-
-alter table budget add constraint fk_budget_user foreign key (user_id) references user (id);
-alter table budget add constraint fk_budget_user_category foreign key (user_category_id) references user_category (id);
+alter table budget modify column amount bigint not null;
+alter table budget modify column user_id bigint not null;
+# alter table budget modify column register_date mediumint not null;
+# alter table budget modify column user_category_id bigint not null;
+#
+# alter table budget add constraint fk_budget_user foreign key (user_id) references user (id);
+# alter table budget add constraint fk_budget_user_category foreign key (user_category_id) references user_category (id);

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -82,16 +82,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-expenditures-940438351'
               examples:
                 expenditure-create-forbidden:
-                  value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
+                  value: "{\"messages\":[\"다른 사용자의 데이터에 접근할 수 없습니다.\"],\"status\"\
+                    :403}"
         "400":
           description: "400"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-expenditures-940438351'
               examples:
                 expenditure-post-amount-max-error:
                   value: "{\"messages\":[\"최대값은 1조입니다\"],\"status\":400}"
@@ -144,6 +145,45 @@ paths:
                     :\"교통/차량\",\"total\":45,\"percent\":34.09},{\"name\":\"문화생활\"\
                     ,\"total\":44,\"percent\":33.33},{\"name\":\"마트/편의점\",\"total\"\
                     :43,\"percent\":32.58}]}"
+  /api/v1/users:
+    get:
+      tags:
+      - api
+      operationId: user-info
+      parameters:
+      - name: Authorization
+        in: header
+        description: Jwt token
+        required: true
+        schema:
+          type: string
+        example: Bearer jwt.token.here
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-users-272417006'
+              examples:
+                user-info:
+                  value: "{\"email\":\"test@test.com\"}"
+    post:
+      tags:
+      - api
+      operationId: user-create
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/api-v1-users-28069028'
+            examples:
+              user-create:
+                value: "{\"email\":\"test@test.com\",\"username\":\"lee\",\"password\"\
+                  :\"12345678\"}"
+      responses:
+        "201":
+          description: "201"
   /api/v1/account-book/search:
     get:
       tags:
@@ -204,7 +244,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-account-book-search-1099388757'
+                $ref: '#/components/schemas/api-v1-account-book-search-212127721'
               examples:
                 search-account-book:
                   value: |-
@@ -215,21 +255,45 @@ paths:
                         "amount" : 10000,
                         "content" : "점심",
                         "categoryName" : "식비",
-                        "registerTime" : "2022-08-10T03:15:25.062652"
+                        "registerTime" : "2022-08-12T23:35:53.795047"
                       }, {
                         "id" : 1,
                         "type" : "INCOME",
                         "amount" : 50000,
                         "content" : "용돈",
                         "categoryName" : "용돈",
-                        "registerTime" : "2022-08-10T03:15:25.062685"
+                        "registerTime" : "2022-08-12T23:35:53.79508"
                       } ],
                       "currentPage" : 1,
-                      "nextPage" : 2,
-                      "incomeSum" : 50000,
-                      "expenditureSum" : 10000,
-                      "totalSum" : 40000
+                      "nextPage" : 2
                     }
+  /api/v1/budgets/statistics:
+    get:
+      tags:
+      - api
+      operationId: budget_statistics-
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/api-v1-budgets-statistics-1295744875'
+              examples:
+                budget_statistics-month:
+                  value: "{\"registerDate\":\"2022-7\",\"amount\":600,\"expenditure\"\
+                    :60,\"percent\":10,\"budgets\":[{\"userCategoryId\":1,\"categoryName\"\
+                    :\"교통/차량\",\"amount\":100,\"expenditure\":10,\"percent\":10},{\"\
+                    userCategoryId\":2,\"categoryName\":\"문화생활\",\"amount\":200,\"\
+                    expenditure\":20,\"percent\":10},{\"userCategoryId\":3,\"categoryName\"\
+                    :\"마트/편의점\",\"amount\":300,\"expenditure\":30,\"percent\":10}]}"
+                budget_statistics-year:
+                  value: "{\"registerDate\":\"2022-7\",\"amount\":600,\"expenditure\"\
+                    :60,\"percent\":10,\"budgets\":[{\"userCategoryId\":1,\"categoryName\"\
+                    :\"교통/차량\",\"amount\":100,\"expenditure\":10,\"percent\":10},{\"\
+                    userCategoryId\":2,\"categoryName\":\"문화생활\",\"amount\":200,\"\
+                    expenditure\":20,\"percent\":10},{\"userCategoryId\":3,\"categoryName\"\
+                    :\"마트/편의점\",\"amount\":300,\"expenditure\":30,\"percent\":10}]}"
   /api/v1/expenditures/{expenditureId}:
     get:
       tags:
@@ -243,15 +307,15 @@ paths:
         schema:
           type: string
       responses:
-        "400":
-          description: "400"
+        "404":
+          description: "404"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-expenditures-940438351'
               examples:
                 expenditure-get-forbidden:
-                  value: "{\"messages\":[\"해당 지출이 존재 하지 않습니다.\"],\"status\":400}"
+                  value: "{\"messages\":[\"해당 지출이 존재 하지 않습니다.\"],\"status\":404}"
         "200":
           description: "200"
           content:
@@ -260,7 +324,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-expenditures-expenditureId2033270015'
               examples:
                 expenditure-get:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-10T03:15:23.742267\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-12T23:35:52.276524\"\
                     ,\"amount\":20000,\"content\":\"돈까스마시써\",\"userCategoryId\":3,\"\
                     categoryName\":\"식비\"}"
   /api/v1/incomes/:
@@ -275,10 +339,10 @@ paths:
               $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
             examples:
               income-create:
-                value: "{\"registerDate\":\"2022-08-10T03:15:24.756833\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-12T23:35:53.433481\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
               income-create-fail:
-                value: "{\"registerDate\":\"2022-08-10T03:15:24.779977\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-12T23:35:53.454642\",\"amount\"\
                   :1000,\"content\":\"content\",\"userCategoryId\":1}"
       responses:
         "201":
@@ -290,15 +354,15 @@ paths:
               examples:
                 income-create:
                   value: "{\"id\":1}"
-        "400":
-          description: "400"
+        "404":
+          description: "404"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-expenditures-940438351'
               examples:
                 income-create-fail:
-                  value: "{\"messages\":[\"해당 사용자 카테고리는 존재하지 않습니다.\"],\"status\":400}"
+                  value: "{\"messages\":[\"해당 사용자 카테고리는 존재하지 않습니다.\"],\"status\":404}"
   /api/v1/incomes/{incomeId}:
     get:
       tags:
@@ -312,15 +376,15 @@ paths:
         schema:
           type: string
       responses:
-        "400":
-          description: "400"
+        "404":
+          description: "404"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-expenditures-940438351'
               examples:
                 income-find-by-id-fail:
-                  value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
+                  value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":404}"
         "200":
           description: "200"
           content:
@@ -329,7 +393,7 @@ paths:
                 $ref: '#/components/schemas/api-v1-incomes-incomeId-1674408626'
               examples:
                 income-find-by-id:
-                  value: "{\"id\":1,\"registerDate\":\"2022-08-10T03:15:24.793286\"\
+                  value: "{\"id\":1,\"registerDate\":\"2022-08-12T23:35:53.466905\"\
                     ,\"amount\":1000,\"content\":\"content\",\"userCategoryId\":1,\"\
                     categoryName\":\"용돈\"}"
         "403":
@@ -337,10 +401,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-expenditures-940438351'
               examples:
                 income-forbidden:
-                  value: "{\"messages\":[\"권한이 없습니다.\"],\"status\":403}"
+                  value: "{\"messages\":[\"다른 사용자의 데이터에 접근할 수 없습니다.\"],\"status\"\
+                    :403}"
     put:
       tags:
       - api
@@ -359,23 +424,23 @@ paths:
               $ref: '#/components/schemas/api-v1-incomes-incomeId1988379506'
             examples:
               income-update:
-                value: "{\"registerDate\":\"2022-08-10T03:15:24.43504\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-12T23:35:53.116031\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
               income-update-fail:
-                value: "{\"registerDate\":\"2022-08-10T03:15:24.738051\",\"amount\"\
+                value: "{\"registerDate\":\"2022-08-12T23:35:53.419579\",\"amount\"\
                   :2000,\"content\":\"updateContent\",\"userCategoryId\":2}"
       responses:
         "204":
           description: "204"
-        "400":
-          description: "400"
+        "404":
+          description: "404"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/api-v1-incomes-incomeId-940438351'
+                $ref: '#/components/schemas/api-v1-expenditures-940438351'
               examples:
                 income-update-fail:
-                  value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":400}"
+                  value: "{\"messages\":[\"수입 정보가 존재하지 않습니다.\"],\"status\":404}"
     delete:
       tags:
       - api
@@ -409,7 +474,7 @@ components:
               categoryName:
                 type: string
                 description: 카테고리 이름
-    api-v1-incomes-incomeId-940438351:
+    api-v1-expenditures-940438351:
       type: object
       properties:
         messages:
@@ -424,48 +489,6 @@ components:
         status:
           type: number
           description: 에러 코드
-    api-v1-account-book-search-1099388757:
-      type: object
-      properties:
-        totalSum:
-          type: number
-          description: "수입,지출 포함 총합"
-        nextPage:
-          type: number
-          description: 다음 페이지
-        incomeSum:
-          type: number
-          description: 수입의 총합
-        currentPage:
-          type: number
-          description: 현재 페이지
-        results:
-          type: array
-          description: "검색된 지출, 수입 데이터"
-          items:
-            type: object
-            properties:
-              amount:
-                type: number
-                description: 금액
-              registerTime:
-                type: string
-                description: 등록일
-              id:
-                type: number
-                description: 지출 or 수입의 아이디
-              type:
-                type: string
-                description: 지출 or 수입 종류
-              categoryName:
-                type: string
-                description: 카테고리 이름
-              content:
-                type: string
-                description: 내용
-        expenditureSum:
-          type: number
-          description: 지출의 총합
     api-v1-statistics-1753393928:
       type: object
       properties:
@@ -511,6 +534,125 @@ components:
         expenditureTotalSum:
           type: number
           description: 지출 총 합계
+    api-v1-budgets1364090725:
+      type: object
+      properties:
+        amount:
+          type: number
+          description: 예산 금액
+        userCategoryId:
+          type: number
+          description: 유저 카테고리 ID
+        registerDate:
+          type: string
+          description: 예산 등록 날짜
+    api-v1-account-book-search-212127721:
+      type: object
+      properties:
+        nextPage:
+          type: number
+          description: 다음 페이지
+        currentPage:
+          type: number
+          description: 현재 페이지
+        results:
+          type: array
+          description: "검색된 지출, 수입 데이터"
+          items:
+            type: object
+            properties:
+              amount:
+                type: number
+                description: 금액
+              registerTime:
+                type: string
+                description: 등록일
+              id:
+                type: number
+                description: 지출 or 수입의 아이디
+              type:
+                type: string
+                description: 지출 or 수입 종류
+              categoryName:
+                type: string
+                description: 카테고리 이름
+              content:
+                type: string
+                description: 내용
+    api-v1-expenditures-expenditureId2033270015:
+      type: object
+      properties:
+        amount:
+          type: number
+          description: 지출 금액
+        userCategoryId:
+          type: number
+          description: 유저 카테고리 ID
+        id:
+          type: number
+          description: 지출 ID
+        categoryName:
+          type: string
+          description: 카테고리 이름
+        content:
+          type: string
+          description: 내용
+        registerDate:
+          type: string
+          description: 지출 등록 날짜
+    api-v1-users-28069028:
+      type: object
+      properties:
+        password:
+          type: string
+          description: 비밀번호
+        email:
+          type: string
+          description: 이메일
+        username:
+          type: string
+          description: 사용자이름
+    api-v1-users-272417006:
+      type: object
+      properties:
+        email:
+          type: string
+          description: 이메일
+    api-v1-budgets-statistics-1295744875:
+      type: object
+      properties:
+        expenditure:
+          type: number
+          description: 지출 총 금액
+        amount:
+          type: number
+          description: 예산 총 금액
+        budgets:
+          type: array
+          items:
+            type: object
+            properties:
+              expenditure:
+                type: number
+                description: 지출 합계
+              amount:
+                type: number
+                description: 예산 합계
+              userCategoryId:
+                type: number
+                description: 유저 카테고리 ID
+              percent:
+                type: number
+                description: 사용량
+              categoryName:
+                type: string
+                description: 카테고리 이름
+        percent:
+          type: number
+          description: 사용량
+        registerDate:
+          type: string
+          description: 예산 등록일
     api-v1-incomes-incomeId1988379506:
       type: object
       properties:
@@ -553,18 +695,6 @@ components:
         registerDate:
           type: string
           description: 지출 등록 날짜
-    api-v1-budgets1364090725:
-      type: object
-      properties:
-        amount:
-          type: number
-          description: 예산 금액
-        userCategoryId:
-          type: number
-          description: 유저 카테고리 ID
-        registerDate:
-          type: string
-          description: 예산 등록 날짜
     api-v1-incomes-incomeId-1674408626:
       type: object
       properties:
@@ -586,24 +716,3 @@ components:
         registerDate:
           type: string
           description: 수입 등록 날짜
-    api-v1-expenditures-expenditureId2033270015:
-      type: object
-      properties:
-        amount:
-          type: number
-          description: 지출 금액
-        userCategoryId:
-          type: number
-          description: 유저 카테고리 ID
-        id:
-          type: number
-          description: 지출 ID
-        categoryName:
-          type: string
-          description: 카테고리 이름
-        content:
-          type: string
-          description: 내용
-        registerDate:
-          type: string
-          description: 지출 등록 날짜

--- a/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindBudgetByRegisterDateDoc.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindBudgetByRegisterDateDoc.java
@@ -1,0 +1,42 @@
+package com.prgrms.tenwonmoa.common.documentdto;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FindBudgetByRegisterDateDoc {
+	ID(NUMBER, "userCategoryId", "유저 카테고리 ID"),
+	CATEGORY_NAME(STRING, "categoryName", "카테고리 이름"),
+	AMOUNT(NUMBER, "amount", "예산 합계"),
+	EXPENDITURE(NUMBER, "expenditure", "지출 합계"),
+	PERCENT(NUMBER, "percent", "사용량");
+
+	private final JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField())
+			.type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> fieldDescriptors() {
+		return List.of(
+			ID.getFieldDescriptor(),
+			CATEGORY_NAME.getFieldDescriptor(),
+			AMOUNT.getFieldDescriptor(),
+			EXPENDITURE.getFieldDescriptor(),
+			PERCENT.getFieldDescriptor()
+		);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindBudgetWithExpenditureResponseDoc.java
+++ b/src/test/java/com/prgrms/tenwonmoa/common/documentdto/FindBudgetWithExpenditureResponseDoc.java
@@ -1,0 +1,42 @@
+package com.prgrms.tenwonmoa.common.documentdto;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FindBudgetWithExpenditureResponseDoc {
+
+	REGISTER_DATE(STRING, "registerDate", "예산 등록일"),
+	AMOUNT(NUMBER, "amount", "예산 총 금액"),
+	EXPENDITURE(NUMBER, "expenditure", "지출 총 금액"),
+	PERCENT(NUMBER, "percent", "사용량"),
+	BUDGETS(ARRAY, "budgets[].", "예산 지출내역");
+
+	private final JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField())
+			.type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> fieldDescriptors() {
+		return List.of(
+			REGISTER_DATE.getFieldDescriptor(),
+			AMOUNT.getFieldDescriptor(),
+			EXPENDITURE.getFieldDescriptor(),
+			PERCENT.getFieldDescriptor()
+		);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/budget/controller/docs/BudgetControllerTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/budget/controller/docs/BudgetControllerTest.java
@@ -1,15 +1,18 @@
 package com.prgrms.tenwonmoa.domain.budget.controller.docs;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.prgrms.tenwonmoa.common.documentdto.FindBudgetWithExpenditureResponseDoc.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,12 +29,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.tenwonmoa.common.annotation.WithMockCustomUser;
 import com.prgrms.tenwonmoa.common.documentdto.CreateOrUpdateBudgetRequestDoc;
+import com.prgrms.tenwonmoa.common.documentdto.FindBudgetByRegisterDateDoc;
 import com.prgrms.tenwonmoa.common.documentdto.FindBudgetDataDoc;
 import com.prgrms.tenwonmoa.config.JwtConfigure;
 import com.prgrms.tenwonmoa.config.WebSecurityConfig;
 import com.prgrms.tenwonmoa.domain.budget.controller.BudgetController;
 import com.prgrms.tenwonmoa.domain.budget.dto.CreateOrUpdateBudgetRequest;
+import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetByRegisterDate;
 import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetData;
+import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetWithExpenditureResponse;
 import com.prgrms.tenwonmoa.domain.budget.service.BudgetTotalService;
 import com.prgrms.tenwonmoa.domain.user.security.jwt.filter.JwtAuthenticationFilter;
 
@@ -57,11 +63,16 @@ class BudgetControllerTest {
 
 	private CreateOrUpdateBudgetRequest createOrUpdateBudgetRequest = new CreateOrUpdateBudgetRequest(
 		1000L, YearMonth.now(), 1L);
-
 	private List<FindBudgetData> findBudgets = List.of(
 		new FindBudgetData(1L, "교통/차량", 1000L),
 		new FindBudgetData(2L, "문화생활", 2000L),
 		new FindBudgetData(3L, "마트/편의점", 3000L)
+	);
+
+	private List<FindBudgetByRegisterDate> budgets = List.of(
+		new FindBudgetByRegisterDate(1L, "교통/차량", 100L),
+		new FindBudgetByRegisterDate(2L, "문화생활", 200L),
+		new FindBudgetByRegisterDate(3L, "마트/편의점", 300L)
 	);
 
 	@Test
@@ -94,4 +105,77 @@ class BudgetControllerTest {
 				responseFields().andWithPrefix("budgets[].", FindBudgetDataDoc.fieldDescriptors())
 			));
 	}
+
+	@Test
+	@WithMockCustomUser
+	void 월별_예산_통계조회_성공() throws Exception {
+		given(budgetTotalService.searchBudgetWithExpenditure(any(), any(), any()))
+			.willReturn(getFindBudgetWithExpenditureResponse(2022, 07));
+		mockMvc.perform(get(LOCATION_PREFIX + "/statistics")
+				.param("year", "2022")
+				.param("month", "7")
+			)
+			.andDo(print())
+			.andDo(document("budget_statistics-month",
+				responseFields(fieldDescriptors())
+					.andWithPrefix("budgets[].", FindBudgetByRegisterDateDoc.fieldDescriptors())
+			))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@WithMockCustomUser
+	void 연별_예산_통계조회_성공() throws Exception {
+		given(budgetTotalService.searchBudgetWithExpenditure(any(), any(), any()))
+			.willReturn(getFindBudgetWithExpenditureResponse(2022, 07));
+		mockMvc.perform(get(LOCATION_PREFIX + "/statistics")
+				.param("year", "2022")
+			)
+			.andDo(print())
+			.andDo(document("budget_statistics-year",
+				responseFields(fieldDescriptors())
+					.andWithPrefix("budgets[].", FindBudgetByRegisterDateDoc.fieldDescriptors())
+			))
+			.andExpect(status().isOk());
+	}
+
+	private FindBudgetWithExpenditureResponse getFindBudgetWithExpenditureResponse(int year, int month) {
+		Long expenditure = 0L;
+		long amountSum = 0L;
+		long expenditureSum = 0L;
+
+		for (FindBudgetByRegisterDate budget : budgets) {
+			expenditure += 10L;
+			amountSum += budget.getAmount();
+			expenditureSum += expenditure;
+			budget.setExpenditure(expenditure);
+			budget.setPercent(calcPercent(budget.getAmount(), expenditure));
+		}
+		return new FindBudgetWithExpenditureResponse(
+			makeRegisterDate(year, month),
+			amountSum,
+			expenditureSum,
+			calcPercent(amountSum, expenditureSum),
+			budgets
+		);
+	}
+
+	private String makeRegisterDate(Integer year, Integer month) {
+		StringBuffer sb = new StringBuffer();
+		sb.append(year);
+		if (Objects.nonNull(month)) {
+			sb.append("-").append(month);
+		}
+		return sb.toString();
+	}
+
+	private Long calcPercent(Long amount, Long expenditure) {
+		Long percent = 0L;
+		if (expenditure > 0) {
+			double doubleData = ((double)expenditure / amount) * 100;
+			percent = (long)Math.floor(doubleData);
+		}
+		return percent;
+	}
+
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetQueryRepositoryTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/budget/repository/BudgetQueryRepositoryTest.java
@@ -310,6 +310,11 @@ class BudgetQueryRepositoryTest extends RepositoryFixture {
 		Category category4 = save(new Category("ct4", EXPENDITURE));
 		Category category5 = save(new Category("ct5", EXPENDITURE));
 
+		Category incomeCategory1 = save(new Category("income1", INCOME));
+		Category incomeCategory2 = save(new Category("income2", INCOME));
+		save(createUserCategory(user, incomeCategory1));
+		save(createUserCategory(user, incomeCategory2));
+
 		uc1 = save(createUserCategory(user, category1));
 		uc2 = save(createUserCategory(user, category2));
 		uc3 = save(createUserCategory(user, category3));

--- a/src/test/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalServiceTest.java
@@ -186,4 +186,30 @@ class BudgetTotalServiceTest {
 		// then
 		assertThat(result.getRegisterDate()).isEqualTo("2022");
 	}
+
+	@Test
+	void 예산0원_지출발생한경우_퍼센트는_지출금액으로반환() {
+		given(budgetQueryRepository.searchExpendituresExistBudget(any(), any(), any()))
+			.willReturn(expenditures);
+		List<FindBudgetByRegisterDate> budgets = List.of(
+			new FindBudgetByRegisterDate(1L, categories[0], 0L),
+			new FindBudgetByRegisterDate(2L, categories[1], 0L),
+			new FindBudgetByRegisterDate(3L, categories[2], 0L)
+		);
+		given(budgetQueryRepository.searchBudgetByRegisterDate(any(), any(), any()))
+			.willReturn(budgets);
+
+		// when
+		FindBudgetWithExpenditureResponse result = budgetTotalService.searchBudgetWithExpenditure(
+			userId, 2022, null);
+		// then
+		assertThat(result.getBudgets()).extracting((data) -> data.getUserCategoryId(),
+				(data) -> data.getCategoryName(),
+				(data) -> data.getAmount(),
+				(data) -> data.getExpenditure(),
+				(data) -> data.getPercent())
+			.contains(tuple(1L, categories[0], 0L, 122860L, 122860L),
+				tuple(2L, categories[1], 0L, 46700L, 46700L),
+				tuple(3L, categories[2], 0L, 43700L, 43700L));
+	}
 }


### PR DESCRIPTION
## 개요
- 예산 컨트롤러 테스트 작성

## 추가기능
- 예산 컨트롤러 테스트 작성

## 변경사항(Optional)
- 유저별 카테고리 정보조회할 때.. 잘못들어간 데이터가 있었습니다.
  - A유저가 B의 카테고리를 가지고 있었음 (잘못저장된 데이터)
  - 이 경우 조회대상에서 제거하기위해 Budget조건에 userId를 추가했습니다.

- 유저별 카테고리 정보조회시 지출에 대한 분류만 가져올 수 있도록 변경했습니다.

- 기존에 예산 통계조회시 예산금액이 0원으로 계산되는 경우 예외를 처리했습니다.
  - 비즈니스 로직상 0원이상의 데이터를 조회하기 때문에 이 조건은 타지않을 가능성이 매우높습니다.
  - 하지만 총 금액을 구하면서 해당 로직을 타면서 예외처리가 되었습니다. (total 구하면서 같은메서드를 호출)
  - 이러한 경우 percent를 지출금액이되도록했습니다.
    - ex) 예산0원 지출123원이면 percent 123
    
- dev의 budget테이블 migration진행되지 않아서 추가했습니다.
