### PR TITLE
[#197] 일일 상세내역 paging을 날짜가아닌 지출과 수입의 건으로 pagination version 2

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/AccountBookQueryController.java
@@ -12,15 +12,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.prgrms.tenwonmoa.domain.accountbook.dto.CalendarCondition;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindCalendarResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.MonthCondition;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.YearMonthCondition;
 import com.prgrms.tenwonmoa.domain.accountbook.service.AccountBookQueryService;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
+import com.prgrms.tenwonmoa.domain.common.page.PageResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,6 +44,22 @@ public class AccountBookQueryController {
 		PageCustomRequest pageRequest = new PageCustomRequest(page, size);
 		PageCustomImpl<FindDayAccountResponse> response = accountBookQueryService.findDailyAccount(userId, pageRequest,
 			date);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping("/daily")
+	public ResponseEntity<PageResponse<FindDayAccountResponse>> findDailyAccountVer2(
+		@AuthenticationPrincipal Long userId,
+		@RequestParam int year,
+		@RequestParam int month,
+		@RequestParam(value = "page", defaultValue = "1") int page,
+		@RequestParam(value = "size", defaultValue = "10") int size
+	) {
+		YearMonthCondition condition = new YearMonthCondition(year, month);
+		PageCustomRequest pageRequest = new PageCustomRequest(page, size);
+		PageResponse<FindDayAccountResponse> response = accountBookQueryService.findDailyAccountVer2(userId,
+			pageRequest,
+			condition);
 		return ResponseEntity.ok().body(response);
 	}
 
@@ -82,7 +99,7 @@ public class AccountBookQueryController {
 		@RequestParam(value = "year") int year,
 		@RequestParam("month") int month
 	) {
-		CalendarCondition condition = new CalendarCondition(year, month);
+		YearMonthCondition condition = new YearMonthCondition(year, month);
 		FindCalendarResponse response = accountBookQueryService.findCalendarAccount(userId, condition);
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/YearMonthCondition.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/YearMonthCondition.java
@@ -6,13 +6,13 @@ import java.util.Calendar;
 
 import com.prgrms.tenwonmoa.exception.message.Message;
 
-public class CalendarCondition {
+public class YearMonthCondition {
 
 	private final int year;
 	private final int month;
 	private static final Calendar CALENDAR_INSTANCE = Calendar.getInstance();
 
-	public CalendarCondition(int year, int month) {
+	public YearMonthCondition(int year, int month) {
 		checkArgument(year >= 1900 && year <= 3000, Message.INVALID_YEAR.getMessage());
 		checkArgument(month >= 1 && month <= 12, Message.INVALID_MONTH.getMessage());
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookQueryService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/AccountBookQueryService.java
@@ -5,15 +5,16 @@ import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.prgrms.tenwonmoa.domain.accountbook.dto.CalendarCondition;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindCalendarResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindDayAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindMonthAccountResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindSumResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.MonthCondition;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.YearMonthCondition;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.AccountBookQueryRepository;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomImpl;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
+import com.prgrms.tenwonmoa.domain.common.page.PageResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -41,7 +42,13 @@ public class AccountBookQueryService {
 		return accountBookQueryRepository.findMonthAccount(userId, condition);
 	}
 
-	public FindCalendarResponse findCalendarAccount(Long userId, CalendarCondition condition) {
+	public PageResponse<FindDayAccountResponse> findDailyAccountVer2(Long userId,
+		PageCustomRequest pageRequest,
+		YearMonthCondition condition) {
+		return accountBookQueryRepository.findDailyAccountVer2(userId, pageRequest, condition);
+	}
+
+	public FindCalendarResponse findCalendarAccount(Long userId, YearMonthCondition condition) {
 		return accountBookQueryRepository.findCalendarAccount(userId, condition);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/common/page/PageInternalElementsImpl.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/common/page/PageInternalElementsImpl.java
@@ -1,0 +1,43 @@
+package com.prgrms.tenwonmoa.domain.common.page;
+
+import java.util.List;
+
+public class PageInternalElementsImpl<T> extends ChunksCustom<T> implements PageResponse<T> {
+
+	private final int currentPage;
+
+	private final int pageSize;
+
+	private final long totalElements;
+
+	public PageInternalElementsImpl(PageCustomRequest pageRequest, long totalElements, List<T> results) {
+		super(results);
+		this.currentPage = pageRequest.getPage();
+		this.pageSize = pageRequest.getSize();
+		this.totalElements = totalElements;
+	}
+
+	@Override
+	public int getCurrentPage() {
+		return currentPage;
+	}
+
+	@Override
+	public Integer getNextPage() {
+		return this.currentPage == getTotalPages() ? null : currentPage + 1;
+	}
+
+	@Override
+	public long getTotalElements() {
+		return this.totalElements;
+	}
+
+	@Override
+	public int getTotalPages() {
+		if (totalElements == 0) {
+			return 1;
+		}
+		return this.pageSize == 0 ? 1 : (int)Math.ceil((double)totalElements / (double)this.pageSize);
+	}
+
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/common/page/PageResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/common/page/PageResponse.java
@@ -1,0 +1,17 @@
+package com.prgrms.tenwonmoa.domain.common.page;
+
+import java.util.List;
+
+public interface PageResponse<T> {
+
+	int getCurrentPage();
+
+	Integer getNextPage();
+
+	int getTotalPages();
+
+	long getTotalElements();
+
+	List<T> getResults();
+
+}

--- a/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
+++ b/src/main/java/com/prgrms/tenwonmoa/exception/message/Message.java
@@ -60,7 +60,10 @@ public enum Message {
 
 	// 달력 요청
 	INVALID_YEAR("년도는 1900년에서 3000년 이하입니다."),
-	INVALID_MONTH("월은 1월에서 12월 이하입니다.");
+	INVALID_MONTH("월은 1월에서 12월 이하입니다."),
+
+	// Page 요쳥
+	INVALID_PAGE_NUMBER("해당 페이지는 존재하지 않습니다.");
 
 	private final String message;
 


### PR DESCRIPTION
## 개요

페이징 기준이 날짜로 할 경우 애매하다.
ex) 8.30에 데이터가 100개가 들어가있다면...?

현재 응답 명세를 깨뜨리지 않고 간다.
페이지 기준을 지출과 수입건으로 개선하자.

## 변경 후

- union 쿼리를 활용해서 데이터를 가져왔습니다.
- total CountQuery를 이용하였습니다 -> 잘못된 페이징 요청을 막기 위해
- 그후 incomeSome, expendiureSum 합계를 구한 후
- PageResponse로 내보냈습니다.

총 쿼리 네 개

## 응답

```json
{
    "results": [
        {
            "registerDate": "2022-08-29",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 1,
                    "type": "INCOME",
                    "amount": 25000,
                    "content": "도둑질",
                    "categoryName": "부수입",
                    "registerTime": "2022-08-29T00:00:00"
                }
            ]
        },
        {
            "registerDate": "2022-08-27",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 2,
                    "type": "INCOME",
                    "amount": 25000,
                    "content": "도둑질",
                    "categoryName": "부수입",
                    "registerTime": "2022-08-27T00:00:00"
                }
            ]
        },
        {
            "registerDate": "2022-08-25",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 3,
                    "type": "INCOME",
                    "amount": 25000,
                    "content": "도둑질",
                    "categoryName": "부수입",
                    "registerTime": "2022-08-25T00:00:00"
                }
            ]
        },
        {
            "registerDate": "2022-08-23",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 4,
                    "type": "INCOME",
                    "amount": 25000,
                    "content": "도둑질",
                    "categoryName": "부수입",
                    "registerTime": "2022-08-23T00:00:00"
                }
            ]
        },
        {
            "registerDate": "2022-08-21",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 5,
                    "type": "INCOME",
                    "amount": 25000,
                    "content": "도둑질",
                    "categoryName": "부수입",
                    "registerTime": "2022-08-21T00:00:00"
                }
            ]
        },
        {
            "registerDate": "2022-08-19",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 6,
                    "type": "INCOME",
                    "amount": 25000,
                    "content": "도둑질",
                    "categoryName": "부수입",
                    "registerTime": "2022-08-19T00:00:00"
                }
            ]
        },
        {
            "registerDate": "2022-08-17",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 7,
                    "type": "INCOME",
                    "amount": 25000,
                    "content": "도둑질",
                    "categoryName": "부수입",
                    "registerTime": "2022-08-17T00:00:00"
                }
            ]
        },
        {
            "registerDate": "2022-08-15",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 8,
                    "type": "INCOME",
                    "amount": 25000,
                    "content": "도둑질",
                    "categoryName": "부수입",
                    "registerTime": "2022-08-15T00:00:00"
                }
            ]
        },
        {
            "registerDate": "2022-08-13",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 9,
                    "type": "INCOME",
                    "amount": 25000,
                    "content": "도둑질",
                    "categoryName": "부수입",
                    "registerTime": "2022-08-13T00:00:00"
                }
            ]
        },
        {
            "registerDate": "2022-08-11",
            "incomeSum": 0,
            "expenditureSum": 0,
            "dayDetails": [
                {
                    "id": 7,
                    "type": "EXPENDITURE",
                    "amount": 5000,
                    "content": "테스트",
                    "categoryName": "교통/차량",
                    "registerTime": "2022-08-11T01:30:00"
                }
            ]
        }
    ],
    "currentPage": 1,
    "totalElements": 17,
    "totalPages": 2,
    "nextPage": 2
}

```

## TODO

형재 pageResponse 수현체를 PageInternalElementsImpl로 했습니다.
현재 PageCustomImp을 그대로 수정해서 사용하려 했으나
윌리엄거까지 함께 수정할 경우 파급효과로 pr이 너무 커질 것같아서 한 번 끊었습니다.

