### PR TITLE
[#215] 검색 합계 반환 API -서비스, 컨트롤러

### DIFF
--- a/docs/search-account-book.adoc
+++ b/docs/search-account-book.adoc
@@ -3,3 +3,7 @@
 === 지출, 수입 검색
 
 operation::search-account-book/[snippets='http-request,request-parameters,http-response,response-fields']
+
+=== 검색 합계
+
+operation::search-sum-account-book/[snippets='http-request,request-parameters,http-response,response-fields']

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/controller/SearchAccountBookController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookSumResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.service.SearchAccountBookCmd;
 import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookService;
 import com.prgrms.tenwonmoa.domain.category.service.FindUserCategoryService;
@@ -56,6 +57,25 @@ public class SearchAccountBookController {
 			SearchAccountBookCmd.of(categories, minPrice, maxPrice, start, end, content), pageRequest);
 
 		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/search/sum")
+	public ResponseEntity<FindAccountBookSumResponse> getSumOfSearchResult(
+		@AuthenticationPrincipal Long userId,
+		@RequestParam(defaultValue = "") String categories,
+		@RequestParam(defaultValue = "") String content,
+		@RequestParam(required = false, name = "minprice") @Min(0L) @Max(1_000_000_000_000L) Long minPrice,
+		@RequestParam(required = false, name = "maxprice") @Min(0L) @Max(1_000_000_000_000L) Long maxPrice,
+		@RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
+		@RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end
+	) {
+
+		categories = categories.isEmpty() ? getAllCategories(userId) : categories;
+
+		FindAccountBookSumResponse sumResponse = accountBookService.getSumOfAccountBooks(userId,
+			SearchAccountBookCmd.of(categories, minPrice, maxPrice, start, end, content));
+
+		return ResponseEntity.ok(sumResponse);
 	}
 
 	private String getAllCategories(Long userId) {

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindAccountBookSumResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindAccountBookSumResponse.java
@@ -13,7 +13,9 @@ public class FindAccountBookSumResponse {
 
 	private final Long totalSum;
 
-	public static FindAccountBookSumResponse of(Long incomeSum, Long expenditureSum){
+	public static FindAccountBookSumResponse of(Long incomeSum, Long expenditureSum) {
+		incomeSum = incomeSum == null ? 0 : incomeSum;
+		expenditureSum = expenditureSum == null ? 0 : expenditureSum;
 		return new FindAccountBookSumResponse(incomeSum, expenditureSum, incomeSum - expenditureSum);
 	}
 }

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindAccountBookSumResponse.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/dto/FindAccountBookSumResponse.java
@@ -1,0 +1,19 @@
+package com.prgrms.tenwonmoa.domain.accountbook.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FindAccountBookSumResponse {
+
+	private final Long incomeSum;
+
+	private final Long expenditureSum;
+
+	private final Long totalSum;
+
+	public static FindAccountBookSumResponse of(Long incomeSum, Long expenditureSum){
+		return new FindAccountBookSumResponse(incomeSum, expenditureSum, incomeSum - expenditureSum);
+	}
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookService.java
@@ -1,7 +1,5 @@
 package com.prgrms.tenwonmoa.domain.accountbook.service;
 
-import static com.google.common.base.Preconditions.*;
-
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -9,7 +7,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.tenwonmoa.domain.accountbook.dto.AccountBookItem;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookSumResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.service.SearchAccountBookCmd;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.ExpenditureRepository;
+import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.SearchAccountBookRepository;
 import com.prgrms.tenwonmoa.domain.common.page.PageCustomRequest;
 
@@ -22,16 +23,27 @@ public class SearchAccountBookService {
 
 	private final SearchAccountBookRepository repository;
 
+	private final ExpenditureRepository expenditureRepository;
+
+	private final IncomeRepository incomeRepository;
+
 	public FindAccountBookResponse searchAccountBooks(Long authenticatedId, SearchAccountBookCmd cmd,
 		PageCustomRequest pageRequest) {
-
-		checkArgument(cmd.getMinPrice() <= cmd.getMaxPrice(), "최소값은 최대값 보다 작아야 합니다");
-		checkArgument(cmd.getStart().compareTo(cmd.getEnd()) <= 0, "시작일은 종료일 전이여야 합니다");
 
 		List<AccountBookItem> accountBookItems = repository.searchAccountBook(cmd.getMinPrice(), cmd.getMaxPrice(),
 			cmd.getStart(), cmd.getEnd(), cmd.getContent(), cmd.getCategories(), authenticatedId, pageRequest);
 
 		return FindAccountBookResponse.of(pageRequest, accountBookItems);
+	}
+
+	public FindAccountBookSumResponse getSumOfAccountBooks(Long authenticatedId, SearchAccountBookCmd cmd) {
+		Long expenditureSum = expenditureRepository.getSumOfExpenditure(cmd.getMinPrice(), cmd.getMaxPrice(),
+			cmd.getStart(), cmd.getEnd(), cmd.getContent(), cmd.getCategories(), authenticatedId);
+
+		Long incomeSum = incomeRepository.getSumOfIncome(cmd.getMinPrice(), cmd.getMaxPrice(),
+			cmd.getStart(), cmd.getEnd(), cmd.getContent(), cmd.getCategories(), authenticatedId);
+
+		return FindAccountBookSumResponse.of(incomeSum, expenditureSum);
 	}
 
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/SearchAccountBookDocsTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/docs/SearchAccountBookDocsTest.java
@@ -32,6 +32,7 @@ import com.prgrms.tenwonmoa.config.WebSecurityConfig;
 import com.prgrms.tenwonmoa.domain.accountbook.controller.SearchAccountBookController;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.AccountBookItem;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookResponse;
+import com.prgrms.tenwonmoa.domain.accountbook.dto.FindAccountBookSumResponse;
 import com.prgrms.tenwonmoa.domain.accountbook.dto.service.SearchAccountBookCmd;
 import com.prgrms.tenwonmoa.domain.accountbook.service.SearchAccountBookService;
 import com.prgrms.tenwonmoa.domain.category.CategoryType;
@@ -113,4 +114,42 @@ class SearchAccountBookDocsTest {
 				)
 			);
 	}
+
+	@Test
+	@WithMockCustomUser
+	void 지출_수입_검색_데이터의_합() throws Exception {
+		FindAccountBookSumResponse response = FindAccountBookSumResponse.of(10000L, 20000L);
+
+		given(accountBookService.getSumOfAccountBooks(anyLong(), any(SearchAccountBookCmd.class)))
+			.willReturn(response);
+
+		mockMvc.perform(get("/api/v1/account-book/search/sum")
+				.param("categories", "1,2,3")
+				.param("minprice", "1000")
+				.param("maxprice", "50000")
+				.param("start", "2022-08-01")
+				.param("end", "2022-08-10")
+				.param("content", "점심"))
+			.andExpect(status().isOk())
+			.andDo(
+				document("search-sum-account-book",
+					Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+					Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+					requestParameters(
+						parameterWithName("categories").description("유저카테고리 아이디").optional(),
+						parameterWithName("minprice").description("최소 가격").optional(),
+						parameterWithName("maxprice").description("최대 가격").optional(),
+						parameterWithName("start").description("시작 등록일").optional(),
+						parameterWithName("end").description("종료 등록일").optional(),
+						parameterWithName("content").description("지출, 수입의 내용").optional()
+					),
+					responseFields(
+						fieldWithPath("incomeSum").type(JsonFieldType.NUMBER).description("수입의 총합"),
+						fieldWithPath("expenditureSum").type(JsonFieldType.NUMBER).description("지출의 총합"),
+						fieldWithPath("totalSum").type(JsonFieldType.NUMBER).description("지출, 수입의 총합")
+					)
+				)
+			);
+	}
+
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/SearchAccountBookIntegrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/controller/intergration/SearchAccountBookIntegrationTest.java
@@ -144,11 +144,54 @@ class SearchAccountBookIntegrationTest extends BaseControllerIntegrationTest {
 	}
 
 	@Test
+	void 금액_최소값이_최대값보다_크면_검색_실패() throws Exception {
+		mvc.perform(get("/api/v1/account-book/search")
+				.header(HttpHeaders.AUTHORIZATION, accessToken)
+				.param("minprice", "10000")
+				.param("maxprice", "10"))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void 시작일이_종료일보다_뒤이면_검색_실패() throws Exception {
+		mvc.perform(get("/api/v1/account-book/search")
+				.header(HttpHeaders.AUTHORIZATION, accessToken)
+				.param("start", "2022-01-01")
+				.param("end", "2021-12-31"))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
 	void 금액의_범위를_벗어나는_값_전송시_조회_실패() throws Exception {
 		validateRequest("minprice", "-1");
 		validateRequest("maxprice", "-1");
 		validateRequest("minprice", "1_000_000_000_001");
 		validateRequest("maxprice", "1_000_000_000_001");
+	}
+
+	@Test
+	void 검색데이터_합계_Api() throws Exception {
+		//given
+		Long incomeCategoryId = 카테고리_등록("INCOME", "월급");
+		Long expenditureCategoryId = 카테고리_등록("EXPENDITURE", "식비");
+		수입_등록(incomeCategoryId, 10000L, "용돈", LocalDateTime.now());
+		지출_등록(expenditureCategoryId, 5000L, "점심", LocalDateTime.now());
+
+		String categories = String.join(",", String.valueOf(incomeCategoryId), String.valueOf(expenditureCategoryId));
+
+		//when
+		//then
+		mvc.perform(get("/api/v1/account-book/search/sum")
+				.header(HttpHeaders.AUTHORIZATION, accessToken)
+				.param("categories", categories)
+				.param("minprice", "0")
+				.param("maxprice", "5000")
+				.param("start", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+				.param("end", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+				.param("content", ""))
+			.andExpect(jsonPath("$.incomeSum").value(0))
+			.andExpect(jsonPath("$.expenditureSum").value(5000))
+			.andExpect(jsonPath("$.totalSum").value(-5000));
 	}
 
 	private void validateRequest(String field, String value) throws Exception {

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookServiceTest.java
@@ -108,4 +108,24 @@ class SearchAccountBookServiceTest {
 		assertThat(sumOfAccountBooks.getIncomeSum()).isEqualTo(20000L);
 		assertThat(sumOfAccountBooks.getTotalSum()).isEqualTo(10000L);
 	}
+
+	@Test
+	void 해당하는_지출_데이터가_존재하지_않을시_합계는_0반환() {
+		SearchAccountBookCmd cmd = SearchAccountBookCmd.of("1,2,3", AMOUNT_MIN, AMOUNT_MAX,
+			LEFT_MOST_REGISTER_DATE, RIGHT_MOST_REGISTER_DATE, "");
+
+		given(expenditureRepository.getSumOfExpenditure(cmd.getMinPrice(), cmd.getMaxPrice(), cmd.getStart(),
+			cmd.getEnd(), cmd.getContent(), cmd.getCategories(), userId)).willReturn(0L);
+
+		given(incomeRepository.getSumOfIncome(cmd.getMinPrice(), cmd.getMaxPrice(), cmd.getStart(),
+			cmd.getEnd(), cmd.getContent(), cmd.getCategories(), userId)).willReturn(20000L);
+
+		FindAccountBookSumResponse sumOfAccountBooks = accountBookService.getSumOfAccountBooks(userId,
+			cmd);
+
+		assertThat(sumOfAccountBooks.getExpenditureSum()).isEqualTo(0);
+		assertThat(sumOfAccountBooks.getIncomeSum()).isEqualTo(20000L);
+		assertThat(sumOfAccountBooks.getTotalSum()).isEqualTo(20000L);
+
+	}
 }

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/SearchAccountBookServiceTest.java
@@ -92,17 +92,18 @@ class SearchAccountBookServiceTest {
 
 	@Test
 	void 가계부_검색후_합계_조회_성공() {
-		SearchAccountBookCmd cmd = SearchAccountBookCmd.of("1,2,3", AMOUNT_MIN, AMOUNT_MAX,
+		SearchAccountBookCmd mockCmd = SearchAccountBookCmd.of("1,2,3", AMOUNT_MIN, AMOUNT_MAX,
 			LEFT_MOST_REGISTER_DATE, RIGHT_MOST_REGISTER_DATE, "");
 
-		given(expenditureRepository.getSumOfExpenditure(cmd.getMinPrice(), cmd.getMaxPrice(), cmd.getStart(),
-			cmd.getEnd(), cmd.getContent(), cmd.getCategories(), userId)).willReturn(10000L);
+		given(expenditureRepository.getSumOfExpenditure(mockCmd.getMinPrice(), mockCmd.getMaxPrice(),
+			mockCmd.getStart(), mockCmd.getEnd(), mockCmd.getContent(), mockCmd.getCategories(), userId))
+			.willReturn(10000L);
 
-		given(incomeRepository.getSumOfIncome(cmd.getMinPrice(), cmd.getMaxPrice(), cmd.getStart(),
-			cmd.getEnd(), cmd.getContent(), cmd.getCategories(), userId)).willReturn(20000L);
+		given(incomeRepository.getSumOfIncome(mockCmd.getMinPrice(), mockCmd.getMaxPrice(), mockCmd.getStart(),
+			mockCmd.getEnd(), mockCmd.getContent(), mockCmd.getCategories(), userId)).willReturn(20000L);
 
 		FindAccountBookSumResponse sumOfAccountBooks = accountBookService.getSumOfAccountBooks(userId,
-			cmd);
+			mockCmd);
 
 		assertThat(sumOfAccountBooks.getExpenditureSum()).isEqualTo(10000L);
 		assertThat(sumOfAccountBooks.getIncomeSum()).isEqualTo(20000L);
@@ -110,18 +111,19 @@ class SearchAccountBookServiceTest {
 	}
 
 	@Test
-	void 해당하는_지출_데이터가_존재하지_않을시_합계는_0반환() {
-		SearchAccountBookCmd cmd = SearchAccountBookCmd.of("1,2,3", AMOUNT_MIN, AMOUNT_MAX,
+	void 해당하는_지출_데이터가_존재하지_않을시_합계는_0을_반환() {
+		SearchAccountBookCmd mockCmd = SearchAccountBookCmd.of("1,2,3", AMOUNT_MIN, AMOUNT_MAX,
 			LEFT_MOST_REGISTER_DATE, RIGHT_MOST_REGISTER_DATE, "");
 
-		given(expenditureRepository.getSumOfExpenditure(cmd.getMinPrice(), cmd.getMaxPrice(), cmd.getStart(),
-			cmd.getEnd(), cmd.getContent(), cmd.getCategories(), userId)).willReturn(0L);
+		given(
+			expenditureRepository.getSumOfExpenditure(mockCmd.getMinPrice(), mockCmd.getMaxPrice(), mockCmd.getStart(),
+				mockCmd.getEnd(), mockCmd.getContent(), mockCmd.getCategories(), userId)).willReturn(0L);
 
-		given(incomeRepository.getSumOfIncome(cmd.getMinPrice(), cmd.getMaxPrice(), cmd.getStart(),
-			cmd.getEnd(), cmd.getContent(), cmd.getCategories(), userId)).willReturn(20000L);
+		given(incomeRepository.getSumOfIncome(mockCmd.getMinPrice(), mockCmd.getMaxPrice(), mockCmd.getStart(),
+			mockCmd.getEnd(), mockCmd.getContent(), mockCmd.getCategories(), userId)).willReturn(20000L);
 
 		FindAccountBookSumResponse sumOfAccountBooks = accountBookService.getSumOfAccountBooks(userId,
-			cmd);
+			mockCmd);
 
 		assertThat(sumOfAccountBooks.getExpenditureSum()).isEqualTo(0);
 		assertThat(sumOfAccountBooks.getIncomeSum()).isEqualTo(20000L);


### PR DESCRIPTION
## 개요

- 검색 데이터의 합을 반환하는 API 구성

## 추가기능
- 검색 데이터의 합을 반환하는 서비스, 컨트롤러 
- 검색 데이터 합 rest docs 작성


## 사용방법(Optional)

- 검색 api와 마찬가지로 쿼리파라미터를 요청. (page, size는 제외)

![image](https://user-images.githubusercontent.com/78348340/184465791-fdaf538b-d670-4ece-a6d1-0b88a0c64bba.png)
![image](https://user-images.githubusercontent.com/78348340/184465796-181e6790-e72b-4384-a4ec-1ecd7233e36f.png)
