### PR TITLE
[#229] 유저 정보 조회시 토큰 값이 비었을 때 생기는 오류 해결

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package com.prgrms.tenwonmoa.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -48,8 +49,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 			.cors()
 				.and()
 			.authorizeRequests()
-				.antMatchers("/api/v1/users", "/api/v1/users/login", "/api/v1/users/refresh", "/docs/**",
-					"api/v1/oauth2/**", "/login/**")
+				.antMatchers("/docs/**")
+					.permitAll()
+				.antMatchers(HttpMethod.POST, "/api/v1/users", "/api/v1/users/login",  "/api/v1/users/refresh")
 					.permitAll()
 				.anyRequest().authenticated()
 				.and()

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/security/jwt/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.prgrms.tenwonmoa.domain.user.security.jwt.filter;
 
 import java.io.IOException;
+import java.util.NoSuchElementException;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -22,7 +23,6 @@ import com.prgrms.tenwonmoa.domain.user.repository.UserRepository;
 import com.prgrms.tenwonmoa.domain.user.security.jwt.JwtConst;
 import com.prgrms.tenwonmoa.domain.user.security.jwt.repository.LogoutAccessTokenRedisRepository;
 import com.prgrms.tenwonmoa.domain.user.security.jwt.service.TokenProvider;
-import com.prgrms.tenwonmoa.exception.InvalidTokenException;
 import com.prgrms.tenwonmoa.exception.UnauthorizedUserException;
 import com.prgrms.tenwonmoa.exception.message.Message;
 
@@ -88,7 +88,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private void checkUserExists(String token) {
 		String email = tokenProvider.validateAndGetEmail(token);
 		if (!userRepository.existsByEmail(email)) {
-			throw new InvalidTokenException(Message.INVALID_TOKEN);
+			throw new NoSuchElementException(Message.USER_NOT_FOUND.getMessage());
 		}
 	}
 


### PR DESCRIPTION
## 개요

- 다음 오류에 대한 해결 [Issue#229](https://github.com/prgrms-web-devcourse/Team-10jo-10wonmoa-BE/issues/229)

## 원인

- 유저 정보를 조회하는 url은 다음과 같음 GET api/v1/users
- WebSecurtyConfig에 /users 는 permitAll()로 세팅 돼 있었음
- 따라서 유저 정보 요청은 토큰 값이 없어도 실행이 됨
![image](https://user-images.githubusercontent.com/43159295/184497775-da4817ae-98f8-4efc-b6de-5ef993edb4fb.png)

## 해결

- POST 요청만 permitAll 로 변경
![image](https://user-images.githubusercontent.com/43159295/184497808-60e104b2-7a0b-4f89-bad1-9d8b6b38d09c.png)

## 변경사항(Optional)

- JwtAuthenticationFilter
유저가 없을 때 log에 찍히는 에러 변경
"잘못된 토큰 요청입니다" -> "해당 사용자는 존재하지 않습니다."
에러 응답은 "똑같이 잘못된 토큰 요청입니다."로 나감


