### PR TITLE
[#217] 비밀번호 확인 로직 추가

### DIFF
--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/controller/UserController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prgrms.tenwonmoa.domain.user.User;
+import com.prgrms.tenwonmoa.domain.user.dto.CheckPasswordRequest;
 import com.prgrms.tenwonmoa.domain.user.dto.CreateUserRequest;
 import com.prgrms.tenwonmoa.domain.user.dto.FindUserResponse;
 import com.prgrms.tenwonmoa.domain.user.dto.LoginUserRequest;
@@ -64,6 +66,14 @@ public class UserController {
 	@DeleteMapping("/delete")
 	public ResponseEntity<Void> delete(@AuthenticationPrincipal Long userId) {
 		userService.deleteUser(userId);
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/password/check")
+	public ResponseEntity<Void> passwordCheck(@AuthenticationPrincipal Long userId,
+		@Valid @RequestBody CheckPasswordRequest checkPasswordRequest) {
+		User user = userService.findById(userId);
+		userService.checkPassword(user.getPassword(), checkPasswordRequest.getPassword());
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/dto/CheckPasswordRequest.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/dto/CheckPasswordRequest.java
@@ -1,0 +1,21 @@
+package com.prgrms.tenwonmoa.domain.user.dto;
+
+import static com.prgrms.tenwonmoa.domain.user.UserConst.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CheckPasswordRequest {
+
+	@Size(min = MIN_PASSWORD_LENGTH, max = MAX_PASSWORD_LENGTH, message = "비밀번호 길이를 맞춰주세요")
+	@NotBlank(message = "비밀번호를 채워주세요")
+	private String password;
+
+}

--- a/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/user/service/UserService.java
@@ -28,7 +28,6 @@ public class UserService {
 	private final JwtService jwtService;
 	private final UserDeleteService userDeleteService;
 
-
 	public User findById(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new NoSuchElementException(Message.USER_NOT_FOUND.getMessage()));
@@ -50,15 +49,15 @@ public class UserService {
 		User user = userRepository.findByEmail(email)
 			.orElseThrow(() -> new IllegalArgumentException(Message.INVALID_EMAIL_OR_PASSWORD.getMessage()));
 
-		if (!checkPassword(user.getPassword(), password)) {
-			throw new IllegalArgumentException(Message.INVALID_EMAIL_OR_PASSWORD.getMessage());
-		}
+		checkPassword(user.getPassword(), password);
 
 		return jwtService.generateToken(user.getId(), email);
 	}
 
-	private boolean checkPassword(String encodedPassword, String requestPassword) {
-		return passwordEncoder.matches(requestPassword, encodedPassword);
+	public void checkPassword(String encodedPassword, String requestPassword) {
+		if (!passwordEncoder.matches(requestPassword, encodedPassword)) {
+			throw new IllegalArgumentException(Message.INVALID_EMAIL_OR_PASSWORD.getMessage());
+		}
 	}
 
 	@Transactional


### PR DESCRIPTION
## 개요

- 회원 탈퇴 전 비밀번호를 확인하는 로직 추가

## 사용방법(Optional)

- 비밀번호가 일치하면 200 ok 응답
- 틀리면 에러 응답 "email 또는 비밀번호가 잘못 됨"

## 기타
- 기능 작성이 완료되었습니다.
- 이제 유저 컨트롤러 테스트 작성하겠습니다
