### PR TITLE
[#235] 파일로그 설정제거

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,13 +4,6 @@
             converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
     <property name="CONSOLE_LOG_PATTERN"
               value="%clr(%d{HH:mm:ss.SSS}){cyan} [%thread] %clr(%-5level) %logger{36} - %msg%n"/>
-
-    <property name="COMMON_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss} %-5level %msg %n"/>
-
-    <property name="LOG_PATH" value="./logs"/>
-    <property name="LOG_FILE_NAME" value="tenwonmoa"/>
-
     <springProperty name="SLACK_WEBHOOK_URL" source="logging.slack.webhook-url"/>
 
     <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
@@ -19,7 +12,7 @@
         <iconEmoji>:stuck_out_tongue_winking_eye:</iconEmoji>
         <colorCoding>true</colorCoding>
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>${COMMON_LOG_PATTERN}</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %msg %n</pattern>
         </layout>
     </appender>
 
@@ -36,24 +29,9 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>${COMMON_LOG_PATTERN}</pattern>
-        </encoder>
-        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
-             </timeBasedFileNamingAndTriggeringPolicy>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-    </appender>
-
     <root level="info">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ASYNC_SLACK"/>
-        <appender-ref ref="FILE"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
## 개요
- 파일로그 설정제거
- 최초 Cloud Watch적용하려고 로그를 파일로 남겼는데 배포환경에서 문제가 좀 있었습니다.
- `ERROR in ch.qos.logback.core.rolling.RollingFileAppender[FILE] - Failed to create parent directories for [/opt/codedeploy-agent/./logs/tenwonmoa.log]`
- CodeDeploy돌면서 디렉토리를 만들 때 권한이 없는것 같아서 배포할때마다 서버가 죽어버리네요..
- 이거를 CodeDeploy에서 권한있는 디렉터리를 미리 만들도록 시도해보았는데.. 잘안되었습니다.
- 우선 파일로그 설정을 제거하고 최종 프로젝트 리뷰 후에 다시 반영해보도록하겠습니다.🥲

