### PR TITLE
[#247] 무중단 배포 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,5 @@ out/
 /deploy
 
 ### Private ###
-/src/main/resources/application-dev.yml
+/src/main/resources/application-dev*.yml
 /src/main/resources/application-custom.yml

--- a/appspec.yml
+++ b/appspec.yml
@@ -21,6 +21,6 @@ hooks:
       timeout: 60
       runas: ubuntu
   ValidateService:
-    - location: health.sh # 부트가 정상적으로 실해오댔는지 확인
+    - location: health.sh # 새 스프링 부트가 정상적으로 실행됐는지 확인
       timeout: 60
       runas: ubuntu

--- a/appspec.yml
+++ b/appspec.yml
@@ -12,7 +12,15 @@ permissions:
     group: ubuntu
 
 hooks:
+  AfterInstall:
+    - location: stop.sh # Nginx 와 연결되지 않은 부트 종료
+      timeout: 60
+      runas: ubuntu
   ApplicationStart:
-    - location: deploy.sh
+    - location: start.sh # Nginx 와 연결되어 있지 않은 Port로 새 버전의 부트 시작
+      timeout: 60
+      runas: ubuntu
+  ValidateService:
+    - location: health.sh # 부트가 정상적으로 실해오댔는지 확인
       timeout: 60
       runas: ubuntu

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+source ${ABSDIR}/switch.sh
+
+IDLE_PORT=$(find_idle_port)
+
+echo "> Health Check Start!"
+echo "> IDLE_PORT: $IDLE_PORT"
+echo "> curl -s http://localhost:$IDLE_PORT/profile "
+sleep 10
+
+for RETRY_COUNT in {1..10}
+do
+  RESPONSE=$(curl -s http://localhost:${IDLE_PORT}/profile)
+  UP_COUNT=$(echo $RESPONSE} | grep 'dev' | wc -l)
+
+  if [ ${UP_COUNT} - ge 1 ]
+  then # $up_count >= 1 (dev 문자열이 있는지 검증)
+    echo "> Health check 성공"
+    switch_proxy
+    break
+  else
+    echo "> Health check의 응답을 알 수 없거나 혹은 실행 상태가 아닙니다."
+    echo "> Health check: ${RESPONSE}"
+  fi
+
+  if [ ${RETRY_COUNT} - eq 10 ]
+  then
+    echo "> Health check 실패."
+    echo "> 엔진엑스에 연결하지 않고 배포를 종료합니다."
+    exit 1
+  fi
+
+  echo "> Health check 연결 실패. 재시도..."
+  sleep 10
+done

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -34,7 +34,3 @@ function find_idle_port()
     echo "8081"
   fi
 }
-
-
-find_idle_profile
-find_idle_port

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -5,7 +5,7 @@ function find_idle_profile()
 {
   RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/profile)
 
-  if [ ${RESPONSE_CODE} -ge 400 ] # 400보다 크면
+  if [ ${RESPONSE_CODE} -ge 400 ] # 400보다 크면(에러인 경우) dev2를 default로 둔다.
   then
     CURRENT_PROFILE=dev2
   else

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -3,13 +3,13 @@
 # 쉬고있는 profile 찾기
 function find_idle_profile()
 {
-  RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/profile)
+  RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/profile)
 
   if [ ${RESPONSE_CODE} -ge 400 ] # 400보다 크면(에러인 경우) dev2를 default로 둔다.
   then
     CURRENT_PROFILE=dev2
   else
-    CURRENT_PROFILE=$(curl -s http://localhost:8080/profile)
+    CURRENT_PROFILE=$(curl -s http://localhost/profile)
   fi
 
   if [ ${CURRENT_PROFILE} == dev ]

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# 쉬고있는 profile 찾기
+function find_idle_profile()
+{
+  RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/profile)
+
+  if [ ${RESPONSE_CODE} -ge 400 ] # 400보다 크면
+  then
+    CURRENT_PROFILE=dev2
+  else
+    CURRENT_PROFILE=$(curl -s http://localhost:8080/profile)
+  fi
+
+  if [ ${CURRENT_PROFILE} == dev ]
+  then
+    IDLE_PROFILE=dev2
+  else
+    IDLE_PROFILE=dev
+  fi
+
+  echo "${IDLE_PROFILE}"
+}
+
+# 쉬고 있는 profile 의 port 찾기
+function find_idle_port()
+{
+  IDLE_PROFILE=$(find_idle_profile)
+
+  if [ ${IDLE_PROFILE} == dev ]
+  then
+    echo "8080"
+  else
+    echo "8081"
+  fi
+}
+
+
+find_idle_profile
+find_idle_port

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
 
 REPOSITORY="/home/ubuntu/app"
 PROJECT_NAME="tenwonmoa"
@@ -37,5 +41,9 @@ sudo docker-compose -f $REPOSITORY/zip/docker-compose-dev.yml up -d
 
 echo "> $JAR_NAME 실행"
 
-nohup java -jar -Dspring.profiles.active=dev $JAR_NAME --server.port=8080 \
+IDLE_PROFILE=$(find_idle_profile)
+
+echo "> $JAR_NAME 을 profile=$IDLE_PROFILE 로 실행."
+
+nohup java -jar -Dspring.profiles.active=${IDLE_PROFILE} \
 $JAR_NAME > $REPOSITORY/nohup.out 2>&1 &

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+
+IDLE_PORT=$(find_idle_port)
+
+echo "> $IDLE_PORT 에서 구동 중인 pid 확인"
+IDLE_PID=$(lsof -ti tcp:${IDLE_PORT})
+
+if [ -z ${IDLE_PID} ]
+then
+  echo "> 현재 구동중 애플리케이션이 없으므로 종료하지 않습니다."
+else
+  echo "> kill -15 $IDLE_PID"
+  kill -15 ${IDLE_PID}
+  sleep 5
+fi

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+
+function switch_proxy() {
+  IDLE_PORT=$(find_idle_port)
+
+  echo "> 전환할 Port: $IDLE_PORT"
+  echo "> Port 전환"
+  echo "set \$service_url http://localhost:${IDLE_PORT};" | sudo tee /etc/nginx/conf.d/service-url.inc
+
+  echo "> 엔진엑스 Reload"
+  sudo service nginx reload
+}

--- a/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/tenwonmoa/config/WebSecurityConfig.java
@@ -49,7 +49,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 			.cors()
 				.and()
 			.authorizeRequests()
-				.antMatchers("/docs/**")
+				.antMatchers("/docs/**", "/profile")
 					.permitAll()
 				.antMatchers(HttpMethod.POST, "/api/v1/users", "/api/v1/users/login",  "/api/v1/users/refresh")
 					.permitAll()

--- a/src/main/java/com/prgrms/tenwonmoa/domain/common/deploy/ProfileController.java
+++ b/src/main/java/com/prgrms/tenwonmoa/domain/common/deploy/ProfileController.java
@@ -1,0 +1,26 @@
+package com.prgrms.tenwonmoa.domain.common.deploy;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ProfileController {
+	private static final List<String> DEV_PROFILES = Arrays.asList("dev", "dev2");
+	private static final String DEFAULT_PROFILE = "default";
+	private final Environment env;
+
+	@GetMapping("/profile")
+	public String profile() {
+		List<String> profiles = Arrays.asList(env.getActiveProfiles());
+		String defaultProfile = profiles.isEmpty() ? DEFAULT_PROFILE : profiles.get(0);
+
+		return profiles.stream().filter(DEV_PROFILES::contains).findAny().orElse(defaultProfile);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/common/deploy/ProfileControllerUnitTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/common/deploy/ProfileControllerUnitTest.java
@@ -1,0 +1,59 @@
+package com.prgrms.tenwonmoa.domain.common.deploy;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class ProfileControllerUnitTest {
+
+	@Test
+	void dev_profile_조회() {
+		// given
+		String expectedProfile = "dev";
+		MockEnvironment env = new MockEnvironment();
+		env.addActiveProfile(expectedProfile);
+		env.addActiveProfile("other1");
+		env.addActiveProfile("other2");
+
+		ProfileController controller = new ProfileController(env);
+
+		// when
+		String profile = controller.profile();
+
+		// then
+		assertThat(profile).isEqualTo(expectedProfile);
+	}
+
+	@Test
+	void dev_profile_없으면_첫번째조회() {
+		// given
+		String expectedProfile = "other1";
+		MockEnvironment env = new MockEnvironment();
+		env.addActiveProfile(expectedProfile);
+		env.addActiveProfile("other2");
+
+		ProfileController controller = new ProfileController(env);
+
+		// when
+		String profile = controller.profile();
+
+		// then
+		assertThat(profile).isEqualTo(expectedProfile);
+	}
+
+	@Test
+	void active_profile_없으면_default_조회() {
+		// given
+		String expectedProfile = "default";
+		MockEnvironment env = new MockEnvironment();
+
+		ProfileController controller = new ProfileController(env);
+
+		// when
+		String profile = controller.profile();
+
+		// then
+		assertThat(profile).isEqualTo(expectedProfile);
+	}
+}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/common/deploy/intergration/ProfileControllerIntergrationTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/common/deploy/intergration/ProfileControllerIntergrationTest.java
@@ -1,0 +1,25 @@
+package com.prgrms.tenwonmoa.domain.common.deploy.intergration;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ProfileControllerIntergrationTest {
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@Test
+	void profile_인증없이_호출가능() {
+		String expected = "default";
+
+		ResponseEntity<String> response = restTemplate.getForEntity("/profile", String.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isEqualTo(expected);
+	}
+}


### PR DESCRIPTION
## 개요
- 무중단 배포가 가능하게 한다.

## 설명
- Nginx를 통해 http(https)요청을 8080, 8081포트로 번갈아 포워딩한다.

## 추가기능

- `/profile` end point를 통해 현재 실행중인 profile을 확인.

## 변경사항(Optional)

- /profile요청 권한 부여(WebSecurityConfig.java)
- 배포 스크립트 변경
  - stop.sh -> idle port로 실행중인 어플리케이션 종료
  - start.sh -> idle port를 확인 후, 실행
    - 기존의 deploy.sh의 기능과 유사
  - switch.sh -> Nginx가 바라보는 포트를 변경한다. (8080 or 8081)
  - health.sh -> 새로운 부트가 정상 실행됐는지 확인 후 switch

## 사용방법(Optional)

- stop -> start -> health 순서로 처리 됨
- 현재 Nginx가 보고있지 않은 port의 어플리케이션을 종료, 시작 후, health를 통해 정상적으로 실행중인지 최종 확인한 후, Nginx의 설정을 변경한다.