### PR TITLE
[#253] Arguement Matchers 수정 

### DIFF
--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/IncomeServiceTest.java
@@ -2,7 +2,6 @@ package com.prgrms.tenwonmoa.domain.accountbook.service;
 
 import static com.prgrms.tenwonmoa.common.fixture.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.NoSuchElementException;
@@ -18,52 +17,47 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.prgrms.tenwonmoa.domain.accountbook.Income;
 import com.prgrms.tenwonmoa.domain.accountbook.repository.IncomeRepository;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
-import com.prgrms.tenwonmoa.domain.user.User;
 import com.prgrms.tenwonmoa.exception.message.Message;
 
 @DisplayName("수입 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
 class IncomeServiceTest {
+	public static final Long AUTH_ID = 1L;
+	public static final Long INCOME_ID = 1L;
+	private static final Income income = createIncome(createUserCategory(createUser(), createIncomeCategory()));
+	private static final Income mockIncome = mock(Income.class);
+	private static final UserCategory mockUserCategory = mock(UserCategory.class);
+
 	@Mock
 	private IncomeRepository incomeRepository;
 
 	@InjectMocks
 	private IncomeService incomeService;
 
-	private final Income income = createIncome(createUserCategory(createUser(), createIncomeCategory()));
-
-	private final User mockUser = mock(User.class);
-	private final Income mockIncome = mock(Income.class);
-	private final UserCategory mockUserCategory = mock(UserCategory.class);
-
 	@Test
 	void 수입저장_성공() {
 		given(incomeRepository.save(income)).willReturn(income);
-
-		Long savedId = incomeService.save(income);
-		assertAll(
-			() -> assertThat(savedId).isEqualTo(income.getId()),
-			() -> verify(incomeRepository).save(income)
-		);
+		// when
+		incomeService.save(income);
+		// then
+		verify(incomeRepository).save(income);
 	}
 
 	@Test
 	void 아이디로_수입조회_성공() {
 		given(incomeRepository.findById(anyLong())).willReturn(Optional.of(mockIncome));
-		given(mockIncome.getUser()).willReturn(mockUser);
 		given(mockIncome.getUserCategory()).willReturn(mockUserCategory);
-		doNothing().when(mockUser).validateLoginUser(anyLong());
 
-		incomeService.findIncome(mockIncome.getId(), anyLong());
+		incomeService.findIncome(AUTH_ID, INCOME_ID);
 		verify(incomeRepository).findById(anyLong());
 	}
 
 	@Test
 	void 아이디로_조회_수입정보가없으면_실패() {
-		given(incomeRepository.findById(any(Long.class))).willThrow(
+		given(incomeRepository.findById(anyLong())).willThrow(
 			new NoSuchElementException(Message.INCOME_NOT_FOUND.getMessage()));
 
-		assertThatThrownBy(() -> incomeRepository.findById(1L))
+		assertThatThrownBy(() -> incomeRepository.findById(INCOME_ID))
 			.isInstanceOf(NoSuchElementException.class)
 			.hasMessage(Message.INCOME_NOT_FOUND.getMessage());
 	}

--- a/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/StatisticsServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/accountbook/service/StatisticsServiceTest.java
@@ -22,6 +22,19 @@ import com.prgrms.tenwonmoa.domain.accountbook.repository.StatisticsQueryReposit
 class StatisticsServiceTest {
 	private static final List<String> INCOME_DEFAULT = List.of("용돈", "상여", "금융소득");
 	private static final List<String> EXPENDITURE_DEFAULT = List.of("교통/차량", "문화생활", "마트/편의점");
+	private static final Long AUTH_ID = 1L;
+	private static final Integer YEAR = 2022;
+	private static final Integer MONTH = 01;
+	private static List<FindStatisticsData> incomes = List.of(
+		new FindStatisticsData(INCOME_DEFAULT.get(0), 30L),
+		new FindStatisticsData(INCOME_DEFAULT.get(1), 20L),
+		new FindStatisticsData(INCOME_DEFAULT.get(2), 10L)
+	);
+	private static List<FindStatisticsData> expenditures = List.of(
+		new FindStatisticsData(EXPENDITURE_DEFAULT.get(0), 45L),
+		new FindStatisticsData(EXPENDITURE_DEFAULT.get(1), 44L),
+		new FindStatisticsData(EXPENDITURE_DEFAULT.get(2), 43L)
+	);
 	@Mock
 	private StatisticsQueryRepository statisticsQueryRepository;
 	@InjectMocks
@@ -29,17 +42,12 @@ class StatisticsServiceTest {
 
 	@Test
 	void 통계_조회_성공_행위검증() {
-		// given
-		List<FindStatisticsData> incomes = mock(List.class);
-		List<FindStatisticsData> expenditures = mock(List.class);
-
-		given(statisticsQueryRepository.searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(incomes);
-		given(statisticsQueryRepository.searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(
-			expenditures);
-
+		given(statisticsQueryRepository.searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt()))
+			.willReturn(incomes);
+		given(statisticsQueryRepository.searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt()))
+			.willReturn(expenditures);
 		// when
-		statisticsService.searchStatistics(anyLong(), anyInt(), anyInt());
-
+		statisticsService.searchStatistics(AUTH_ID, YEAR, MONTH);
 		// then
 		verify(statisticsQueryRepository).searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt());
 		verify(statisticsQueryRepository).searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt());
@@ -47,27 +55,15 @@ class StatisticsServiceTest {
 
 	@Test
 	void 통계_조회_성공_상태검증() {
-		List<FindStatisticsData> incomes = List.of(
-			new FindStatisticsData(INCOME_DEFAULT.get(0), 30L),
-			new FindStatisticsData(INCOME_DEFAULT.get(1), 20L),
-			new FindStatisticsData(INCOME_DEFAULT.get(2), 10L));
-		// given
-		List<FindStatisticsData> expenditures = List.of(
-			new FindStatisticsData(EXPENDITURE_DEFAULT.get(0), 45L),
-			new FindStatisticsData(EXPENDITURE_DEFAULT.get(1), 44L),
-			new FindStatisticsData(EXPENDITURE_DEFAULT.get(2), 43L)
-		);
-		given(statisticsQueryRepository.searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(incomes);
-		given(statisticsQueryRepository.searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(
-			expenditures);
-
+		given(statisticsQueryRepository.searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt()))
+			.willReturn(incomes);
+		given(statisticsQueryRepository.searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt()))
+			.willReturn(expenditures);
 		// when
-		FindStatisticsResponse findStatisticsResponse = statisticsService.searchStatistics(1L, 2022, 07);
-		System.out.println(findStatisticsResponse);
-
+		FindStatisticsResponse findStatisticsResponse = statisticsService.searchStatistics(AUTH_ID, YEAR, MONTH);
 		// then
-		assertThat(findStatisticsResponse.getYear()).isEqualTo(2022);
-		assertThat(findStatisticsResponse.getMonth()).isEqualTo(07);
+		assertThat(findStatisticsResponse.getYear()).isEqualTo(YEAR);
+		assertThat(findStatisticsResponse.getMonth()).isEqualTo(MONTH);
 		assertThat(findStatisticsResponse.getIncomeTotalSum()).isEqualTo(60L);
 		assertThat(findStatisticsResponse.getExpenditureTotalSum()).isEqualTo(132L);
 		assertThat(findStatisticsResponse.getIncomes()).hasSize(3);
@@ -80,19 +76,17 @@ class StatisticsServiceTest {
 
 	@Test
 	void 통계_조회_성공_상태검증_비어있는경우() {
-		List<FindStatisticsData> incomes = Collections.emptyList();
-		List<FindStatisticsData> expenditures = Collections.emptyList();
-
-		given(statisticsQueryRepository.searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(incomes);
-		given(statisticsQueryRepository.searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt())).willReturn(
-			expenditures);
+		given(statisticsQueryRepository.searchIncomeByRegisterDate(anyLong(), anyInt(), anyInt()))
+			.willReturn(Collections.emptyList());
+		given(statisticsQueryRepository.searchExpenditureByRegisterDate(anyLong(), anyInt(), anyInt()))
+			.willReturn(Collections.emptyList());
 
 		// when
-		FindStatisticsResponse findStatisticsResponse = statisticsService.searchStatistics(1L, 2022, 07);
+		FindStatisticsResponse findStatisticsResponse = statisticsService.searchStatistics(AUTH_ID, YEAR, MONTH);
 
 		// then
-		assertThat(findStatisticsResponse.getYear()).isEqualTo(2022);
-		assertThat(findStatisticsResponse.getMonth()).isEqualTo(07);
+		assertThat(findStatisticsResponse.getYear()).isEqualTo(YEAR);
+		assertThat(findStatisticsResponse.getMonth()).isEqualTo(MONTH);
 		assertThat(findStatisticsResponse.getIncomeTotalSum()).isEqualTo(0L);
 		assertThat(findStatisticsResponse.getExpenditureTotalSum()).isEqualTo(0L);
 		assertThat(findStatisticsResponse.getIncomes()).isEmpty();

--- a/src/test/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalServiceTest.java
+++ b/src/test/java/com/prgrms/tenwonmoa/domain/budget/service/BudgetTotalServiceTest.java
@@ -27,7 +27,6 @@ import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetData;
 import com.prgrms.tenwonmoa.domain.budget.dto.FindBudgetWithExpenditureResponse;
 import com.prgrms.tenwonmoa.domain.budget.repository.BudgetQueryRepository;
 import com.prgrms.tenwonmoa.domain.budget.repository.BudgetRepository;
-import com.prgrms.tenwonmoa.domain.category.Category;
 import com.prgrms.tenwonmoa.domain.category.UserCategory;
 import com.prgrms.tenwonmoa.domain.category.service.UserCategoryService;
 import com.prgrms.tenwonmoa.domain.user.User;
@@ -36,6 +35,28 @@ import com.prgrms.tenwonmoa.domain.user.service.UserService;
 @DisplayName("예산 서비스 Total 테스트")
 @ExtendWith(MockitoExtension.class)
 class BudgetTotalServiceTest {
+	private static final CreateOrUpdateBudgetRequest REQUEST = new CreateOrUpdateBudgetRequest(
+		1000L, YearMonth.of(2020, 01), 1L);
+	private static final String[] CATEGORIES = {"패션/미용", "교통/차량", "건강"};
+	private static final Long USER_ID = 1L;
+	private static User user = createUser();
+	private static List<FindBudgetByRegisterDate> budgets = List.of(
+		new FindBudgetByRegisterDate(1L, CATEGORIES[0], 100000L),
+		new FindBudgetByRegisterDate(2L, CATEGORIES[1], 50000L),
+		new FindBudgetByRegisterDate(3L, CATEGORIES[2], 50000L)
+	);
+	private static List<FindBudgetData> findBudgetDataList = List.of(
+		new FindBudgetData(1L, "ct1", 1000L),
+		new FindBudgetData(2L, "ct2", 2000L)
+	);
+	private static Map<Long, Long> expenditures = Map.of(
+		1L, 122860L,
+		2L, 46700L,
+		3L, 43700L
+	);
+	private static UserCategory mockUserCategory = mock(UserCategory.class);
+	private static User mockUser = mock(User.class);
+	private static Budget mockBudget = mock(Budget.class);
 	@Mock
 	private BudgetRepository budgetRepository;
 	@Mock
@@ -46,65 +67,34 @@ class BudgetTotalServiceTest {
 	private BudgetQueryRepository budgetQueryRepository;
 	@InjectMocks
 	private BudgetTotalService budgetTotalService;
-
-	private User user = createUser();
-	private Category category = createExpenditureCategory();
-	private UserCategory userCategory = createUserCategory(user, category);
-	private CreateOrUpdateBudgetRequest createOrUpdateBudgetRequest = new CreateOrUpdateBudgetRequest(
-		1000L, YearMonth.of(2020, 01), userCategory.getId());
-	private String[] categories = {"패션/미용", "교통/차량", "건강"};
-
-	private List<FindBudgetData> findBudgetDataList = List.of(
-		new FindBudgetData(1L, "ct1", 1000L),
-		new FindBudgetData(2L, "ct2", 2000L)
-	);
-
-	private static final Long userId = 1L;
-
-	private Map<Long, Long> expenditures = Map.of(
-		1L, 122860L,
-		2L, 46700L,
-		3L, 43700L
-	);
-	private List<FindBudgetByRegisterDate> budgets = List.of(
-		new FindBudgetByRegisterDate(1L, categories[0], 100000L),
-		new FindBudgetByRegisterDate(2L, categories[1], 50000L),
-		new FindBudgetByRegisterDate(3L, categories[2], 50000L)
-	);
-
 	@Test
 	void 예산_생성_성공() {
-		UserCategory mockUserCategory = mock(UserCategory.class);
-		User mockUser = mock(User.class);
-		given(userCategoryService.findById(any())).willReturn(mockUserCategory);
+		given(userCategoryService.findById(anyLong())).willReturn(mockUserCategory);
 		given(mockUserCategory.getUser()).willReturn(mockUser);
-		doNothing().when(mockUser).validateLoginUser(any());
-		given(userService.findById(any())).willReturn(user);
-		given(budgetRepository.findByUserCategoryIdAndRegisterDate(
-			any(), any())).willReturn(Optional.empty());
-
-		budgetTotalService.createOrUpdateBudget(user.getId(), createOrUpdateBudgetRequest);
+		doNothing().when(mockUser).validateLoginUser(anyLong());
+		given(userService.findById(anyLong())).willReturn(user);
+		given(budgetRepository.findByUserCategoryIdAndRegisterDate(anyLong(), any(YearMonth.class)))
+			.willReturn(Optional.empty());
+		// when
+		budgetTotalService.createOrUpdateBudget(USER_ID, REQUEST);
 		assertAll(
-			() -> verify(userCategoryService).findById(any()),
-			() -> verify(userService).findById(any()),
-			() -> verify(budgetRepository).findByUserCategoryIdAndRegisterDate(any(), any()),
-			() -> verify(budgetRepository).save(any())
+			() -> verify(userCategoryService).findById(anyLong()),
+			() -> verify(userService).findById(anyLong()),
+			() -> verify(budgetRepository).findByUserCategoryIdAndRegisterDate(anyLong(), any(YearMonth.class)),
+			() -> verify(budgetRepository).save(any(Budget.class))
 		);
 	}
 
 	@Test
 	void 예산_생성_업데이트처리되는경우() {
-		Budget mockBudget = mock(Budget.class);
-		UserCategory mockUserCategory = mock(UserCategory.class);
-		User mockUser = mock(User.class);
-		given(userCategoryService.findById(any())).willReturn(mockUserCategory);
+		given(userCategoryService.findById(anyLong())).willReturn(mockUserCategory);
 		given(mockUserCategory.getUser()).willReturn(mockUser);
-		doNothing().when(mockUser).validateLoginUser(any());
-		given(userService.findById(any())).willReturn(mockUser);
-		given(budgetRepository.findByUserCategoryIdAndRegisterDate(
-			any(), any())).willReturn(Optional.of(mockBudget));
-
-		budgetTotalService.createOrUpdateBudget(userId, createOrUpdateBudgetRequest);
+		doNothing().when(mockUser).validateLoginUser(anyLong());
+		given(userService.findById(anyLong())).willReturn(mockUser);
+		given(budgetRepository.findByUserCategoryIdAndRegisterDate(anyLong(), any(YearMonth.class)))
+			.willReturn(Optional.of(mockBudget));
+		// when
+		budgetTotalService.createOrUpdateBudget(USER_ID, REQUEST);
 		assertAll(
 			() -> verify(userCategoryService).findById(any()),
 			() -> verify(userService).findById(any()),
@@ -117,45 +107,43 @@ class BudgetTotalServiceTest {
 	void 예산_생성실패_유저카테고리_없는경우() {
 		given(userCategoryService.findById(any())).willThrow(
 			new NoSuchElementException(USER_CATEGORY_NOT_FOUND.getMessage()));
-		assertThatThrownBy(() -> budgetTotalService.createOrUpdateBudget(user.getId(), createOrUpdateBudgetRequest))
+		assertThatThrownBy(() -> budgetTotalService.createOrUpdateBudget(USER_ID, REQUEST))
 			.isInstanceOf(NoSuchElementException.class)
 			.hasMessage(USER_CATEGORY_NOT_FOUND.getMessage());
 	}
 
 	@Test
 	void 월별_유저카테고리별_예산조회() {
-		YearMonth now = YearMonth.now();
-		given(budgetQueryRepository.searchUserCategoriesWithBudget(any(), any())).willReturn(findBudgetDataList);
+		given(budgetQueryRepository.searchUserCategoriesWithBudget(anyLong(), any(YearMonth.class)))
+			.willReturn(findBudgetDataList);
 		// when
-		budgetTotalService.searchUserCategoriesWithBudget(userId, now);
+		budgetTotalService.searchUserCategoriesWithBudget(USER_ID, YearMonth.now());
 		// then
-		verify(budgetQueryRepository).searchUserCategoriesWithBudget(userId, now);
+		verify(budgetQueryRepository).searchUserCategoriesWithBudget(anyLong(), any(YearMonth.class));
 	}
 
 	@Test
 	void 월연별_예산조회_성공_행위검증() {
-		given(budgetQueryRepository.searchExpendituresExistBudget(any(), any(), any()))
+		given(budgetQueryRepository.searchExpendituresExistBudget(anyLong(), anyInt(), anyInt()))
 			.willReturn(expenditures);
-		given(budgetQueryRepository.searchBudgetByRegisterDate(any(), any(), any()))
+		given(budgetQueryRepository.searchBudgetByRegisterDate(anyLong(), anyInt(), anyInt()))
 			.willReturn(budgets);
 		// when
-		FindBudgetWithExpenditureResponse result = budgetTotalService.searchBudgetWithExpenditure(
-			userId, 2022, 10);
+		budgetTotalService.searchBudgetWithExpenditure(USER_ID, 2022, 10);
 		// then
-		verify(budgetQueryRepository).searchExpendituresExistBudget(userId, 2022, 10);
-		verify(budgetQueryRepository).searchBudgetByRegisterDate(userId, 2022, 10);
+		verify(budgetQueryRepository).searchExpendituresExistBudget(anyLong(), anyInt(), anyInt());
+		verify(budgetQueryRepository).searchBudgetByRegisterDate(anyLong(), anyInt(), anyInt());
 	}
 
 	@Test
 	void 월별_예산조회_성공_상태검증() {
-		given(budgetQueryRepository.searchExpendituresExistBudget(any(), any(), any()))
+		given(budgetQueryRepository.searchExpendituresExistBudget(anyLong(), anyInt(), anyInt()))
 			.willReturn(expenditures);
-		given(budgetQueryRepository.searchBudgetByRegisterDate(any(), any(), any()))
+		given(budgetQueryRepository.searchBudgetByRegisterDate(anyLong(), anyInt(), anyInt()))
 			.willReturn(budgets);
-
 		// when
 		FindBudgetWithExpenditureResponse result = budgetTotalService.searchBudgetWithExpenditure(
-			userId, 2022, 10);
+			USER_ID, 2022, 10);
 		// then
 		long expenditureSum = expenditures.keySet().stream().mapToLong(key -> expenditures.get(key)).sum();
 		long budgetSum = budgets.stream().mapToLong(FindBudgetByRegisterDate::getAmount).sum();
@@ -168,48 +156,46 @@ class BudgetTotalServiceTest {
 				(data) -> data.getAmount(),
 				(data) -> data.getExpenditure(),
 				(data) -> data.getPercent())
-			.contains(tuple(1L, categories[0], 100000L, 122860L, 122L),
-				tuple(2L, categories[1], 50000L, 46700L, 93L),
-				tuple(3L, categories[2], 50000L, 43700L, 87L));
+			.contains(tuple(1L, CATEGORIES[0], 100000L, 122860L, 122L),
+				tuple(2L, CATEGORIES[1], 50000L, 46700L, 93L),
+				tuple(3L, CATEGORIES[2], 50000L, 43700L, 87L));
 	}
 
 	@Test
 	void 연별_예산조회_성공_상태검증() {
-		given(budgetQueryRepository.searchExpendituresExistBudget(any(), any(), any()))
+		given(budgetQueryRepository.searchExpendituresExistBudget(anyLong(), anyInt(), isNull()))
 			.willReturn(expenditures);
-		given(budgetQueryRepository.searchBudgetByRegisterDate(any(), any(), any()))
+		given(budgetQueryRepository.searchBudgetByRegisterDate(anyLong(), anyInt(), isNull()))
 			.willReturn(budgets);
-
 		// when
 		FindBudgetWithExpenditureResponse result = budgetTotalService.searchBudgetWithExpenditure(
-			userId, 2022, null);
+			USER_ID, 2022, null);
 		// then
 		assertThat(result.getRegisterDate()).isEqualTo("2022");
 	}
 
 	@Test
 	void 예산0원_지출발생한경우_퍼센트는_지출금액으로반환() {
-		given(budgetQueryRepository.searchExpendituresExistBudget(any(), any(), any()))
-			.willReturn(expenditures);
-		List<FindBudgetByRegisterDate> budgets = List.of(
-			new FindBudgetByRegisterDate(1L, categories[0], 0L),
-			new FindBudgetByRegisterDate(2L, categories[1], 0L),
-			new FindBudgetByRegisterDate(3L, categories[2], 0L)
+		List<FindBudgetByRegisterDate> zeroBudgets = List.of(
+			new FindBudgetByRegisterDate(1L, CATEGORIES[0], 0L),
+			new FindBudgetByRegisterDate(2L, CATEGORIES[1], 0L),
+			new FindBudgetByRegisterDate(3L, CATEGORIES[2], 0L)
 		);
-		given(budgetQueryRepository.searchBudgetByRegisterDate(any(), any(), any()))
-			.willReturn(budgets);
-
+		given(budgetQueryRepository.searchExpendituresExistBudget(anyLong(), anyInt(), isNull()))
+			.willReturn(expenditures);
+		given(budgetQueryRepository.searchBudgetByRegisterDate(anyLong(), anyInt(), isNull()))
+			.willReturn(zeroBudgets);
 		// when
 		FindBudgetWithExpenditureResponse result = budgetTotalService.searchBudgetWithExpenditure(
-			userId, 2022, null);
+			USER_ID, 2022, null);
 		// then
 		assertThat(result.getBudgets()).extracting((data) -> data.getUserCategoryId(),
 				(data) -> data.getCategoryName(),
 				(data) -> data.getAmount(),
 				(data) -> data.getExpenditure(),
 				(data) -> data.getPercent())
-			.contains(tuple(1L, categories[0], 0L, 122860L, 122860L),
-				tuple(2L, categories[1], 0L, 46700L, 46700L),
-				tuple(3L, categories[2], 0L, 43700L, 43700L));
+			.contains(tuple(1L, CATEGORIES[0], 0L, 122860L, 122860L),
+				tuple(2L, CATEGORIES[1], 0L, 46700L, 46700L),
+				tuple(3L, CATEGORIES[2], 0L, 43700L, 43700L));
 	}
 }


### PR DESCRIPTION
## 변경 전
- 반환값에 사용
- 잦은 any() 사용
- 의미없는 상태검증

## 변경 후
- Argument Matchers 타입명시
  - `anyLong, any(User.class)...`

- 불필요한 코드 제거
  - 전역변수 활용